### PR TITLE
Support directories and recursive browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ See `swayimg --help` or `man swayimg` for details.
 - `f`, `F11`: Toggle full screen mode;
 - `PgDown`, `Space`, `n`: Open next file;
 - `PgUp`, `p`: Open previous file;
+- `N`: Skip to first file in next directory;
+- `P`: Skip to last file in previous directory;
 - `Esc`, `Enter`, `F10`, `q`: Exit the program.
 
 ## Build and install

--- a/bash.completion
+++ b/bash.completion
@@ -7,6 +7,7 @@ _swayimg()
                 -f --fullscreen \
                 -s --scale \
                 -i --info \
+                -r --recursive \
                 -v --version \
                 -h --help"
     if [[ ${cur} == -* ]]; then

--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,7 @@ endif
 
 # source files
 sources = [
+  'src/browser.c',
   'src/draw.c',
   'src/image.c',
   'src/main.c',

--- a/src/browser.c
+++ b/src/browser.c
@@ -7,6 +7,7 @@
 #include <fts.h>
 #include <errno.h>
 #include <limits.h>
+#include <unistd.h>
 
 struct browser {
     /** File list. */
@@ -92,12 +93,22 @@ browser* create_browser(const char** paths, size_t paths_num, bool recursive)
         return NULL;
     }
 
-    for (size_t i = 0; i < paths_num; i++) {
-        if (is_directory(paths[i])) {
-            load_directory(browser, paths[i]);
-        } else {
-            add_file(browser, paths[i]);
+    if (paths_num > 0) {
+        for (size_t i = 0; i < paths_num; i++) {
+            if (is_directory(paths[i])) {
+                load_directory(browser, paths[i]);
+            } else {
+                add_file(browser, paths[i]);
+            }
         }
+    } else {
+        char cwd[PATH_MAX];
+        if (!cwd) {
+            fprintf(stderr, "Unable to get current directory: \n", strerror(errno));
+            return NULL;
+        }
+        getcwd(cwd, PATH_MAX);
+        load_directory(browser, cwd);
     }
     return browser;
 }

--- a/src/browser.c
+++ b/src/browser.c
@@ -115,7 +115,7 @@ browser* create_browser(const char** paths, size_t paths_num, bool recursive)
         load_directory(&loader, cwd, recursive);
     }
 
-    browser* browser = malloc(sizeof(browser));
+    browser* browser = malloc(sizeof(struct browser));
     if (!browser) {
         fprintf(stderr, "Not enough memory\n");
         return NULL;

--- a/src/browser.c
+++ b/src/browser.c
@@ -1,0 +1,136 @@
+#include "browser.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fts.h>
+#include <errno.h>
+#include <limits.h>
+
+struct browser {
+    /** File list. */
+    char** files;
+    int max;
+    int total;
+    int current;
+    bool recursive;   ///< Recurse into subdirectories
+};
+
+void add_file(browser* browser, const char* file)
+{
+    if (browser->max == browser->total) {
+        browser->max *= 2;
+        browser->files = realloc(browser->files, browser->max * sizeof(char*));
+        if (!browser->files) {
+            fprintf(stderr, "Not enough memory\n");
+            return;
+        }
+    }
+    size_t len = strlen(file);
+    browser->files[browser->total] = malloc(len + 1);
+    memcpy(browser->files[browser->total], file, len);
+    browser->files[browser->total][len] = '\0';
+    browser->total++;
+}
+
+int compare(const FTSENT** a, const FTSENT** b)
+{
+    return (strcmp((*a)->fts_name, (*b)->fts_name));
+}
+
+int is_directory(const char *path)
+{
+   struct stat statbuf;
+   if (stat(path, &statbuf) != 0)
+       return 0;
+   return S_ISDIR(statbuf.st_mode);
+}
+
+void load_directory(browser* context, const char *dir) {
+    FTS* file_system = NULL;
+    FTSENT* child = NULL;
+    FTSENT* parent = NULL;
+
+    file_system = fts_open((char* const*)&dir, FTS_COMFOLLOW | FTS_NOCHDIR, &compare);
+
+    if (file_system) {
+        while( (parent = fts_read(file_system))) {
+            child = fts_children(file_system, 0);
+            if (errno != 0) {
+                fprintf(stderr, "Unable to load directory %s: %s\n", dir, strerror(errno));
+            }
+
+            char* file = malloc(PATH_MAX);
+            while (child && child->fts_link) {
+                child = child->fts_link;
+                if (child->fts_info == FTS_F && (context->recursive || child->fts_level == 1)) {
+                    snprintf(file, PATH_MAX, "%s%s", child->fts_path, child->fts_name);
+                    add_file(context, file);
+                }
+            }
+            free(file);
+        }
+        fts_close(file_system);
+    }
+}
+
+browser* create_browser(const char** paths, size_t paths_num, bool recursive)
+{
+    browser* browser = malloc(sizeof(browser));
+    if (!browser) {
+        fprintf(stderr, "Not enough memory\n");
+        return NULL;
+    }
+    browser->max = 1024;
+    browser->total = 0;
+    browser->current = -1;
+    browser->recursive = recursive;
+    browser->files = (char**)malloc(browser->max * sizeof(char*));
+    if (!browser->files) {
+        fprintf(stderr, "Not enough memory\n");
+        return NULL;
+    }
+
+    for (size_t i = 0; i < paths_num; i++) {
+        if (is_directory(paths[i])) {
+            load_directory(browser, paths[i]);
+        } else {
+            add_file(browser, paths[i]);
+        }
+    }
+    return browser;
+}
+
+const char* next_file(browser* context, bool forward)
+{
+    if (context->total == 0) {
+        return NULL;
+    }
+    int initial = context->current;
+    const int delta = forward ? 1 : -1;
+    do {
+        context->current += delta;
+        if (context->current == context->total) {
+            context->current = 0;
+        } else if (context->current < 0) {
+            context->current = context->total - 1;
+        }
+        if (context->current == initial) {
+            // we have looped around all files without finding anything
+            return NULL;
+        }
+    } while (!context->files[context->current]);
+    return context->files[context->current];
+}
+
+const char* current_file(browser* context)
+{
+    return context->files[context->current];
+}
+
+void delete_current_file(browser* context)
+{
+    free(context->files[context->current]);
+    context->files[context->current] = NULL;
+}

--- a/src/browser.c
+++ b/src/browser.c
@@ -155,6 +155,31 @@ const char* get_next_file(bool forward)
     return browser.files[browser.current];
 }
 
+static int dirname_length(const char* dir)
+{
+    int length = strlen(dir);
+    while (length >= 0 && dir[length] != '/') {
+        length--;
+    }
+    return length;
+}
+
+const char* get_next_directory(bool forward)
+{
+    const char* current = browser.files[browser.current];
+    int current_dir_length = dirname_length(current);
+    const char* next = get_next_file(forward);
+    int next_dir_length = dirname_length(next);
+    while (next) {
+        if (current_dir_length != next_dir_length || strncmp(current, next, next_dir_length) != 0) {
+            return next;
+        }
+        next = get_next_file(forward);
+        next_dir_length = dirname_length(next);
+    }
+    return next;
+}
+
 const char* get_current_file()
 {
     return browser.files[browser.current];

--- a/src/browser.c
+++ b/src/browser.c
@@ -30,7 +30,7 @@ typedef struct {
 static void add_file(loader* loader, const char* file)
 {
     if (loader->max == loader->total) {
-        loader->max += 256;
+        loader->max = (loader->max < 32) ? 32 : (loader->max + (loader->max >> 1));
         loader->files = realloc(loader->files, loader->max * sizeof(char*));
         if (!loader->files) {
             fprintf(stderr, "Not enough memory\n");
@@ -92,7 +92,7 @@ static void load_directory(loader* loader, const char* dir, bool recursive)
 bool create_browser(const char** paths, size_t paths_num, bool recursive)
 {
     loader loader;
-    loader.max = 128;
+    loader.max = paths_num;
     loader.total = 0;
     loader.files = (char**)malloc(loader.max * sizeof(char*));
     if (!loader.files) {

--- a/src/browser.h
+++ b/src/browser.h
@@ -3,7 +3,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-typedef struct browser browser;
+struct browser;
+
+extern struct browser browser;
 
 /**
  * Initialize browser.
@@ -11,8 +13,8 @@ typedef struct browser browser;
  * @param[in] paths_num number of paths
  * @return browser instance or NULL on error
  */
-browser* create_browser(const char** paths, size_t paths_num, bool recursive);
-void destroy_browser(browser* context);
+bool init_browser(const char** paths, size_t paths_num, bool recursive);
+void destroy_browser();
 
 /**
  * Get next (or previous) file path.
@@ -20,17 +22,17 @@ void destroy_browser(browser* context);
  * @param[in] forward whether to iterate forwards (iterates backwards when false)
  * @return path of next file
  */
-const char* next_file(browser* context, bool forward);
+const char* get_next_file(bool forward);
 
 /**
  * Get current file path.
  * @param[in] context browser context
  * @return path of current file
  */
-const char* current_file(browser* context);
+const char* get_current_file();
 
 /**
  * Remove current file from browser. It won't be returned on subsequent iterations.
  * @param[in] context browser context
  */
-void skip_current_file(browser* context);
+void skip_current_file();

--- a/src/browser.h
+++ b/src/browser.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 #include <stdlib.h>
 #include <stdbool.h>
 
@@ -9,7 +11,8 @@ typedef struct browser browser;
  * @param[in] paths_num number of paths
  * @return browser instance or NULL on error
  */
-struct browser* create_browser(const char** paths, size_t paths_num, bool recursive);
+browser* create_browser(const char** paths, size_t paths_num, bool recursive);
+void destroy_browser(browser* context);
 
 /**
  * Get next (or previous) file path.
@@ -30,4 +33,4 @@ const char* current_file(browser* context);
  * Remove current file from browser. It won't be returned on subsequent iterations.
  * @param[in] context browser context
  */
-void delete_current_file(browser* context);
+void skip_current_file(browser* context);

--- a/src/browser.h
+++ b/src/browser.h
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+#include <stdbool.h>
+
+typedef struct browser browser;
+
+/**
+ * Initialize browser.
+ * @param[in] paths list of files or directories
+ * @param[in] paths_num number of paths
+ * @return browser instance or NULL on error
+ */
+struct browser* create_browser(const char** paths, size_t paths_num, bool recursive);
+
+/**
+ * Get next (or previous) file path.
+ * @param[in] context browser context
+ * @param[in] forward whether to iterate forwards (iterates backwards when false)
+ * @return path of next file
+ */
+const char* next_file(browser* context, bool forward);
+
+/**
+ * Get current file path.
+ * @param[in] context browser context
+ * @return path of current file
+ */
+const char* current_file(browser* context);
+
+/**
+ * Remove current file from browser. It won't be returned on subsequent iterations.
+ * @param[in] context browser context
+ */
+void delete_current_file(browser* context);

--- a/src/browser.h
+++ b/src/browser.h
@@ -24,6 +24,8 @@ void destroy_browser();
  */
 const char* get_next_file(bool forward);
 
+const char* get_next_directory(bool forward);
+
 /**
  * Get current file path.
  * @param[in] context browser context

--- a/src/main.c
+++ b/src/main.c
@@ -101,6 +101,7 @@ int main(int argc, char* argv[])
     const char* short_opts = "fg:s:irvh";
 
     opterr = 0; // prevent native error messages
+    bool recursive = false;
 
     // parse arguments
     int opt;
@@ -121,7 +122,7 @@ int main(int argc, char* argv[])
                 viewer.show_info = true;
                 break;
             case 'r':
-                viewer.recursive = true;
+                recursive = true;
                 break;
             case 'v':
                 print_version();
@@ -146,6 +147,6 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    return show_image((const char**)&argv[optind], (size_t)argc - optind) ?
+    return show_image((const char**)&argv[optind], (size_t)argc - optind, recursive) ?
            EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -14,11 +14,12 @@
  */
 static void print_help(void)
 {
-    puts("Usage: " APP_NAME " [OPTION...] FILE...");
+    puts("Usage: " APP_NAME " [OPTION...] [FILE|DIR]...");
     puts("  -f, --fullscreen         Full screen mode");
     puts("  -g, --geometry=X,Y,W,H   Set window geometry");
     puts("  -s, --scale=PERCENT      Set initial image scale");
     puts("  -i, --info               Show image properties");
+    puts("  -r, --recursive          Open images in subdirectories recursively");
     puts("  -v, --version            Print version info and exit");
     puts("  -h, --help               Print this help and exit");
 }
@@ -92,11 +93,12 @@ int main(int argc, char* argv[])
         { "geometry",   required_argument, NULL, 'g' },
         { "scale",      required_argument, NULL, 's' },
         { "info",       no_argument,       NULL, 'i' },
+        { "recursive",  no_argument,       NULL, 'r' },
         { "version",    no_argument,       NULL, 'v' },
         { "help",       no_argument,       NULL, 'h' },
         { NULL,         0,                 NULL,  0  }
     };
-    const char* short_opts = "fg:s:ivh";
+    const char* short_opts = "fg:s:irvh";
 
     opterr = 0; // prevent native error messages
 
@@ -117,6 +119,9 @@ int main(int argc, char* argv[])
                 break;
             case 'i':
                 viewer.show_info = true;
+                break;
+            case 'r':
+                viewer.recursive = true;
                 break;
             case 'v':
                 print_version();

--- a/src/main.c
+++ b/src/main.c
@@ -142,11 +142,6 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    if (optind == argc) {
-        fprintf(stderr, "No files to view.\n");
-        return EXIT_FAILURE;
-    }
-
     return show_image((const char**)&argv[optind], (size_t)argc - optind, recursive) ?
            EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,7 @@
 // Copyright (C) 2020 Artem Senichev <artemsen@gmail.com>
 
 #include "config.h"
+#include "browser.h"
 #include "viewer.h"
 
 #include <stdio.h>
@@ -142,13 +143,12 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    viewer.browser = create_browser((const char**)&argv[optind], (size_t)argc - optind, recursive);
-    if (!viewer.browser) {
+    if (!create_browser((const char**)&argv[optind], (size_t)argc - optind, recursive)) {
         return EXIT_FAILURE;
     }
 
     bool rc = show_image();
 
-    destroy_browser(viewer.browser);
+    destroy_browser();
     return rc ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -142,6 +142,13 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    return show_image((const char**)&argv[optind], (size_t)argc - optind, recursive) ?
-           EXIT_SUCCESS : EXIT_FAILURE;
+    viewer.browser = create_browser((const char**)&argv[optind], (size_t)argc - optind, recursive);
+    if (!viewer.browser) {
+        return EXIT_FAILURE;
+    }
+
+    bool rc = show_image();
+
+    destroy_browser(viewer.browser);
+    return rc ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "viewer.h"
+#include "browser.h"
 #include "draw.h"
 #include "window.h"
 #include "image.h"
@@ -255,7 +256,7 @@ static bool load_file(const char* file)
  */
 static bool load_next_file(bool forward)
 {
-    const char* file = next_file(viewer.browser, forward);
+    const char* file = get_next_file(forward);
     if (!file) {
         return false;
     }
@@ -263,9 +264,9 @@ static bool load_next_file(bool forward)
         if(load_file(file)) {
             return true;
         } else {
-            skip_current_file(viewer.browser);
+            skip_current_file();
         }
-        file = next_file(viewer.browser, forward);
+        file = get_next_file(forward);
     }
     return false;
 }
@@ -293,7 +294,7 @@ static void on_redraw(cairo_surface_t* window)
                               "Format: %s\n"
                               "Size:   %ix%i\n"
                               "Scale:  %i%%",
-                              current_file(viewer.browser), ctx.image->format,
+                              get_current_file(), ctx.image->format,
                               img_w, img_h, (int)(ctx.scale * 100));
     }
 

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -12,12 +12,6 @@
 #include <string.h>
 #include <sys/time.h>
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fts.h>
-#include <errno.h>
-#include <limits.h>
-
 #ifndef MAX_PATH
 #define MAX_PATH 4096
 #endif
@@ -55,14 +49,6 @@ struct context {
     /** Coordinates of the top left corner. */
     int x;
     int y;
-
-    /** File list. */
-    struct flist {
-        char** files;
-        int max;
-        int total;
-        int current;
-    } flist;
 };
 static struct context ctx;
 
@@ -273,23 +259,17 @@ static bool load_file(const char* file)
  */
 static bool load_next_file(bool forward)
 {
-    const int delta = forward ? 1 : -1;
-    int idx = ctx.flist.current;
-    idx += delta;
-    while (idx != ctx.flist.current) {
-        if (idx >= ctx.flist.total) {
-            if (ctx.flist.current < 0) {
-                return false; // no one valid file
-            }
-            idx = 0;
-        } else if (idx < 0) {
-            idx = ctx.flist.total - 1;
-        }
-        if (load_file(ctx.flist.files[idx])) {
-            ctx.flist.current = idx;
+    const char* file = next_file(viewer.browser, forward);
+    if (!file) {
+        return false;
+    }
+    while (file) {
+        if(load_file(file)) {
             return true;
+        } else {
+            delete_current_file(viewer.browser);
         }
-        idx += delta;
+        file = next_file(viewer.browser, forward);
     }
     return false;
 }
@@ -317,7 +297,7 @@ static void on_redraw(cairo_surface_t* window)
                               "Format: %s\n"
                               "Size:   %ix%i\n"
                               "Scale:  %i%%",
-                              ctx.flist.files[ctx.flist.current], ctx.image->format,
+                              current_file(viewer.browser), ctx.image->format,
                               img_w, img_h, (int)(ctx.scale * 100));
     }
 
@@ -389,85 +369,7 @@ static bool on_keyboard(xkb_keysym_t key)
     return false;
 }
 
-void add_file(const char* file)
-{
-    if (ctx.flist.max == ctx.flist.total) {
-        ctx.flist.max *= 2;
-        ctx.flist.files = realloc(ctx.flist.files, ctx.flist.max * sizeof(char*));
-        if (!ctx.flist.files) {
-            fprintf(stderr, "Not enough memory\n");
-            return;
-        }
-    }
-    size_t len = strlen(file);
-    ctx.flist.files[ctx.flist.total] = malloc(len + 1);
-    memcpy(ctx.flist.files[ctx.flist.total], file, len);
-    ctx.flist.files[ctx.flist.total][len] = '\0';
-    ctx.flist.total++;
-}
-
-int compare(const FTSENT** a, const FTSENT** b)
-{
-    return (strcmp((*a)->fts_name, (*b)->fts_name));
-}
-
-int is_directory(const char *path)
-{
-   struct stat statbuf;
-   if (stat(path, &statbuf) != 0)
-       return 0;
-   return S_ISDIR(statbuf.st_mode);
-}
-
-void load_directory(const char *dir) {
-    FTS* file_system = NULL;
-    FTSENT* child = NULL;
-    FTSENT* parent = NULL;
-
-    file_system = fts_open((char* const*)&dir, FTS_COMFOLLOW | FTS_NOCHDIR, &compare);
-
-    if (NULL != file_system) {
-        while( (parent = fts_read(file_system)) != NULL) {
-            child = fts_children(file_system, 0);
-            if (errno != 0) {
-                perror("fts_children");
-            }
-
-            char* file = malloc(PATH_MAX);
-            while (NULL != child && NULL != child->fts_link) {
-                child = child->fts_link;
-                if (child->fts_info == FTS_F && (child->fts_level == 1 || viewer.recursive)) {
-                    snprintf(file, PATH_MAX, "%s%s", child->fts_path, child->fts_name);
-                    add_file(file);
-                }
-            }
-            free(file);
-        }
-        fts_close(file_system);
-    }
-}
-
-void process_files(const char** files, size_t files_num)
-{
-    ctx.flist.max = 1024;
-    ctx.flist.total = 0;
-    ctx.flist.current = -1;
-    ctx.flist.files = (char**)malloc(ctx.flist.max * sizeof(char*));
-    if (!ctx.flist.files) {
-        fprintf(stderr, "Not enough memory\n");
-        return;
-    }
-
-    for (size_t i = 0; i < files_num; i++) {
-        if (is_directory(files[i])) {
-            load_directory(files[i]);
-        } else {
-            add_file(files[i]);
-        }
-    }
-}
-
-bool show_image(const char** files, size_t files_num)
+bool show_image(const char** paths, size_t paths_num, bool recursive)
 {
     bool rc = false;
 
@@ -477,7 +379,10 @@ bool show_image(const char** files, size_t files_num)
         .on_keyboard = on_keyboard
     };
 
-    process_files(files, files_num);
+    viewer.browser = create_browser(paths, paths_num, recursive);
+    if (!viewer.browser) {
+        goto done;
+    }
 
     // create unique application id
     char app_id[64];

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -12,10 +12,6 @@
 #include <string.h>
 #include <sys/time.h>
 
-#ifndef MAX_PATH
-#define MAX_PATH 4096
-#endif
-
 // Scale thresholds
 #define MIN_SCALE_PIXEL 10
 #define MAX_SCALE_TIMES 100
@@ -267,7 +263,7 @@ static bool load_next_file(bool forward)
         if(load_file(file)) {
             return true;
         } else {
-            delete_current_file(viewer.browser);
+            skip_current_file(viewer.browser);
         }
         file = next_file(viewer.browser, forward);
     }
@@ -369,7 +365,7 @@ static bool on_keyboard(xkb_keysym_t key)
     return false;
 }
 
-bool show_image(const char** paths, size_t paths_num, bool recursive)
+bool show_image()
 {
     bool rc = false;
 
@@ -378,11 +374,6 @@ bool show_image(const char** paths, size_t paths_num, bool recursive)
         .on_resize = on_resize,
         .on_keyboard = on_keyboard
     };
-
-    viewer.browser = create_browser(paths, paths_num, recursive);
-    if (!viewer.browser) {
-        goto done;
-    }
 
     // create unique application id
     char app_id[64];

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -254,9 +254,9 @@ static bool load_file(const char* file)
  * @param[in] forward move direction (true=forward/false=backward).
  * @return false if no file can be opened
  */
-static bool load_next_file(bool forward)
+static bool load_next_file(bool forward, bool skip_dir)
 {
-    const char* file = get_next_file(forward);
+    const char* file = skip_dir ? get_next_directory(forward) : get_next_file(forward);
     if (!file) {
         return false;
     }
@@ -313,11 +313,15 @@ static bool on_keyboard(xkb_keysym_t key)
     switch (key) {
         case XKB_KEY_SunPageUp:
         case XKB_KEY_p:
-            return load_next_file(false);
+            return load_next_file(false, false);
         case XKB_KEY_SunPageDown:
         case XKB_KEY_n:
         case XKB_KEY_space:
-            return load_next_file(true);
+            return load_next_file(true, false);
+        case XKB_KEY_P:
+            return load_next_file(false, true);
+        case XKB_KEY_N:
+            return load_next_file(true, true);
         case XKB_KEY_Left:
         case XKB_KEY_h:
             return change_position(move_left);
@@ -401,7 +405,7 @@ bool show_image()
     if (!create_window(&handlers, viewer.wnd.width, viewer.wnd.height, app_id)) {
         goto done;
     }
-    if (!load_next_file(true)) {
+    if (!load_next_file(true, false)) {
         fprintf(stderr, "No supported files to view.\n");
         goto done;
     }

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -410,6 +410,7 @@ bool show_image(const char** paths, size_t paths_num, bool recursive)
         goto done;
     }
     if (!load_next_file(true)) {
+        fprintf(stderr, "No supported files to view.\n");
         goto done;
     }
     if (viewer.fullscreen) {

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -21,9 +21,6 @@ extern struct viewer viewer;
 
 /**
  * Start viewer.
- * @param[in] files file list
- * @param[in] files_num number of files
- * @param[in] recursive recurse into subdirectories
  * @return true if operation completed successfully
  */
-bool show_image(const char** paths, size_t paths_num, bool recursive);
+bool show_image();

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -14,6 +14,7 @@ struct viewer {
     struct rect wnd;  ///< Window geometry (NULL=auto)
     bool fullscreen;  ///< Full screen mode
     bool show_info;   ///< Show image info
+    bool recursive;   ///< Recurse into subdirectories
 };
 extern struct viewer viewer;
 

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "sway.h"
-#include "browser.h"
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -15,7 +14,6 @@ struct viewer {
     struct rect wnd;  ///< Window geometry (NULL=auto)
     bool fullscreen;  ///< Full screen mode
     bool show_info;   ///< Show image info
-    browser* browser;
 };
 extern struct viewer viewer;
 

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "sway.h"
+#include "browser.h"
 
 #include <stddef.h>
 #include <stdbool.h>
@@ -14,7 +15,7 @@ struct viewer {
     struct rect wnd;  ///< Window geometry (NULL=auto)
     bool fullscreen;  ///< Full screen mode
     bool show_info;   ///< Show image info
-    bool recursive;   ///< Recurse into subdirectories
+    browser* browser;
 };
 extern struct viewer viewer;
 
@@ -22,6 +23,7 @@ extern struct viewer viewer;
  * Start viewer.
  * @param[in] files file list
  * @param[in] files_num number of files
+ * @param[in] recursive recurse into subdirectories
  * @return true if operation completed successfully
  */
-bool show_image(const char** files, size_t files_num);
+bool show_image(const char** paths, size_t paths_num, bool recursive);

--- a/swayimg.1
+++ b/swayimg.1
@@ -13,6 +13,9 @@ This data is used calculate the position and size of a new window.
 Then the program adds two rules to the Sway: "floating enable" and
 "move position" for \fBswayimg\fR application, creates a new Wayland window and
 draws an image from the specified file.
+.PP
+When no files or directories are supplied on command line current working
+directory will be opened.
 .
 .SH OPTIONS
 .PP

--- a/swayimg.1
+++ b/swayimg.1
@@ -2,7 +2,7 @@
 .SH NAME
 swayimg \- image viewer for Sway
 .SH SYNOPSIS
-swayimg [\fIOPTIONS\fR...] \fIFILE...\fR
+swayimg [\fIOPTIONS\fR...] [\fIFILE\fR|\fIDIR\fR]...
 .SH DESCRIPTION
 The \fBswayimg\fR utility can be used for preview images inside the currently
 focused window (container).
@@ -32,6 +32,8 @@ Set initial scale of the image. The default value is \fB0\fR (auto): if the
 image is greater than the window, it will be zoomed out to fit the window.
 .IP "\fB\-i\fR, \fB\-\-info\fR"
 Show image properties on startup (path, size, current scale etc).
+.IP "\fB\-r\fR, \fB\-\-recursive\fR"
+Display images from subdirectories recursively.
 .
 .SH KEYBINDINGS
 .IP "\fBArrows\fR and vim-like moving keys (\fBh\fR,\fBj\fR,\fBk\fR,\fBl\fR)"

--- a/swayimg.1
+++ b/swayimg.1
@@ -59,6 +59,10 @@ Toggle full screen mode.
 Show next file.
 .IP "\fBPgUp\fR, \fBp\fR"
 Show previous file.
+.IP "\fBN\fR"
+Show first file in next directory.
+.IP "\fBP\fR"
+Show last file in previous directory.
 .IP "\fBEsc\fP, \fBEnter\fP, \fBF10\fP, \fBq\fP"
 Exit the program.
 .


### PR DESCRIPTION
Hi @artemsen,

First of all, thank you for this great tool, I really like it.

I was however missing one small feature: I'd like to open all images in a directory and always typing `path/directory/*.{jpg,bmp,png}` is tedious. So I've added support for loading all files in given directory if the parameter on command line is a directory. Optionally, new option `--recursive` or `-r` can be used to add images from subdirectories as well.

Please let me know what you think about this proposal and if I should make any changes to match your coding standards.