### PR TITLE
Allow reading files from stdin

### DIFF
--- a/swayimgfind
+++ b/swayimgfind
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+show_usage() {
+    echo 'Usage:'
+    echo '  swayimgfind find_arg... [-- swayimg_arg...]'
+    echo '  swayimgfind --help'
+}
+
+parse_options() {
+    SWAYIMG_OPTS=()
+    FIND_OPTS=()
+    ARGS="FIND_OPTS"
+    while [ $# -gt 0 ]; do
+        case $1 in
+        --help) show_usage; exit 0 ;;
+        --)     ARGS="SWAYIMG_OPTS" ;;
+        *)      eval "$ARGS+=($1)" ;;
+        esac
+        shift
+    done
+}
+
+main() {
+    set -e -o pipefail;
+    parse_options "$@"
+    find "${FIND_OPTS[@]}" | build/swayimg "${SWAYIMG_OPTS[@]}"
+}
+
+main "$@"


### PR DESCRIPTION
Currently, the only way to pass list of files to swayimg is via command line arguments. This is (not much, but still) limiting, as the total size of command is limited (2MB on my machine, but could be different on other systems).

This PR allows to pass the file paths on standard output, so it is now posible to do things like `find . -name *.jpg | swayimg`.

The second commit adds simple script wrapping `find` and `swayimg` in single command, so it can be easily integrated into users desktop environment. It allows everything from simple `swayimgfind ~/Photos` to open whole directory structure, to using complex find filters to find and display only some images.

The PR is marked as draft because of missing documentation. If you agree with the code @artemsen, I'll start working on the docs.