### PR TITLE
Fix -Wimplicit-function-declaration on FreeBSD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ project(
 add_project_arguments(
   [
     '-Wno-unused-parameter',
-    '-D_POSIX_C_SOURCE=200809'
+    '-D_XOPEN_SOURCE=700'
   ],
   language: 'c',
 )


### PR DESCRIPTION
According to [POSIX.1-2008](https://pubs.opengroup.org/onlinepubs/9699919799.2016edition/functions/gettimeofday.html) (compare with [POSIX.1-2001](https://pubs.opengroup.org/onlinepubs/009604599/functions/gettimeofday.html)) `gettimeofday` is `OB XSI` ("Obsolescent" + "X/Open System Interfaces"). XSI etxensions are provided by `_XOPEN_SOURCE`, a superset of `_POSIX_C_SOURCE`.
