### PR TITLE
Improve filename completion

### DIFF
--- a/extra/bash.completion
+++ b/extra/bash.completion
@@ -21,6 +21,6 @@ _swayimg()
         COMPREPLY=($(compgen -f -- "${cur}"))
     fi
 } &&
-complete -F _swayimg swayimg
+complete -o filenames -F _swayimg swayimg
 
 # ex: filetype=sh


### PR DESCRIPTION
Currently, when filename completion is being performed, dirnames don't have a slash appended to them and even worse, when completing dirnames, a space is appended instead of completing the contents of the directory. Using the `filenames` option, fixes this.  