### PR TITLE
meson.build: link epoll-shim for non-Linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,8 @@ jxl = dependency('libjxl', required: false)
 if not jxl.found() and (jxl_feature.auto() or jxl_feature.enabled())
   jxl = cc.find_library('libjxl', required: jxl_feature)
 endif
+# Non-Linux
+epoll = dependency('epoll-shim', required: false)
 
 # configuration file
 conf = configuration_data()
@@ -175,6 +177,7 @@ executable(
     # runtime
     rt,
     wlcln,
+    epoll,
     json,
     xkb,
     fontconfig,


### PR DESCRIPTION
Subset of epoll is available on non-Linux via epoll-shim,
check if epoll-shim is available and link to it.

```
ld: error: undefined symbol: timerfd_create
>>> referenced by window.c
>>>               swayimg.p/src_window.c.o:(create_window)

ld: error: undefined symbol: epoll_shim_close
>>> referenced by window.c
>>>               swayimg.p/src_window.c.o:(destroy_window)
>>> referenced by window.c
>>>               swayimg.p/src_window.c.o:(on_keyboard_keymap)
>>> referenced by window.c
>>>               swayimg.p/src_window.c.o:(create_buffer)
>>> referenced 1 more times

ld: error: undefined symbol: epoll_shim_poll
>>> referenced by window.c
>>>               swayimg.p/src_window.c.o:(show_window)

ld: error: undefined symbol: epoll_shim_read
>>> referenced by window.c
>>>               swayimg.p/src_window.c.o:(show_window)

ld: error: undefined symbol: timerfd_settime
>>> referenced by window.c
>>>               swayimg.p/src_window.c.o:(on_keyboard_key)
```