### PR TITLE
Amended English mechanics

### DIFF
--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -15,10 +15,10 @@ swayimgrc \- Swayimg configuration file
 The Swayimg configuration file is a text-based INI file used to override the
 default settings.
 .PP
-The basic element contained in the INI file is the key or property.
-Every key has a name and a value, delimited by an equals sign (=).
-The name appears to the left of the equals sign. The value can contain any
-character. Kay and values are case sensitive.
+The basic element contained in the INI file is the key or property.  Every key
+has a name and a value, delimited by an equals sign (=).  The name appears
+to the left of the equals sign, and the value to the right. The value can
+contain any character. Names and values are case sensitive.
 .PP
 The number sign (#) at the beginning of the line indicates a comment.
 Empty lines and comments are ignored.
@@ -46,12 +46,12 @@ Empty lines and comments are ignored.
 .IP "\fBorder\fR: order of the image list:"
 .nf
 \fInone\fR: unsorted;
-\fIalpha\fR: sort alphabetically (default);
+\fIalpha\fR: sorted alphabetically (default);
 \fIrandom\fR: randomize list.
 .IP "\fBrecursive\fR: read directories recursively, \fIyes\fR or [\fIno\fR];"
-.IP "\fBall\fR: allways open all files in the same directory, \fIyes\fR or [\fIno\fR];"
-.IP "\fBapp_id\fR: set a constant window class/app_id, setting this may break the window layout;"
-.IP "\fBsway\fR: enable or disable integration with Sway WM (window position management), [\fIyes\fR] or \fIno\fR."
+.IP "\fBall\fR: always open all files in the same directory, \fIyes\fR or [\fIno\fR];"
+.IP "\fBapp_id\fR: set a constant window class/app_id. Setting this may break the window layout;"
+.IP "\fBsway\fR: enable or disable integration with sway WM (window position management), [\fIyes\fR] or \fIno\fR."
 .\" example file
 .SH EXAMPLES
 .EX

--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -15,8 +15,8 @@ swayimgrc \- Swayimg configuration file
 The Swayimg configuration file is a text-based INI file used to override the
 default settings.
 .PP
-The basic element contained in the INI file is the key or property.  Every key
-has a name and a value, delimited by an equals sign (=).  The name appears
+The basic element contained in the INI file is the key or property. Every key
+has a name and a value, delimited by an equals sign (=). The name appears
 to the left of the equals sign, and the value to the right. The value can
 contain any character. Names and values are case sensitive.
 .PP


### PR DESCRIPTION
1) The reader is first told that every key has a name and a value. This implies that there are two parts to a key: a name and a value. But parts are not identical to wholes. Later in the same passage the reader is told that keys and values are case sensite. This implies that values are cognates of keys, but we were just told that values were cognates of names, and that these two things were parts of keys.

2) Fixed typo

3) Fixed comma-splice by changing the comma to a period and making two sentences.

Note, there's some inconsistency in punctuation. Certain definitions being capitalized, certain others don't. Also, the docs use two spaces between sentences, but that's an outmoded standard meant for writing on paper. Today, with computers, the standard is one space between sentences.

