### PR TITLE
Set the minimum required meson version to 0.59

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ project(
   ],
   license: 'MIT',
   version: '0.0.0',
+  meson_version: '>=0.59.0',
 )
 
 add_project_arguments(


### PR DESCRIPTION
The disable_auto_if method was introduced in 0.59
https://mesonbuild.com/Reference-manual_returned_feature.html#featuredisable_auto_if