### PR TITLE
bash-completion: Use _filedir for space completion

### DIFF
--- a/extra/bash.completion
+++ b/extra/bash.completion
@@ -21,7 +21,7 @@ _swayimg()
     if [[ ${cur} == -* ]]; then
         COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
      else
-        COMPREPLY=($(compgen -f -- "${cur}"))
+        _filedir
     fi
 } &&
 complete -o filenames -F _swayimg swayimg


### PR DESCRIPTION
compgen -f doesn't play nicely with spaces, and bash-complete has since introduced _filedir which handles all of the gnarly work for file/dir handling.