### PR TITLE
Support for larger BMP DIB headers

### DIFF
--- a/src/formats/bmp.c
+++ b/src/formats/bmp.c
@@ -23,9 +23,9 @@
 #define RLE_ESC_DELTA 2
 
 // Default mask for 16-bit images
-#define MASK555_RED   0x001f
+#define MASK555_RED   0x7c00
 #define MASK555_GREEN 0x03e0
-#define MASK555_BLUE  0x7c00
+#define MASK555_BLUE  0x001f
 #define MASK555_ALPHA 0x0000
 
 // Sizes of DIB Headers


### PR DESCRIPTION
### What was added

Added support for BMP images with DIB headers larger than the standard `BITMAPINFOHEADER`. An example is `BITMAPINFOV5HEADER`, that GIMP outputs.

### How it was added

Consider the figure below. Before, the mask was read from the same place as the color data (purple), immediately after the DIB header. However, mask information is contained **in** the DIB header, in versions that support it. 

![image](https://upload.wikimedia.org/wikipedia/commons/7/75/BMPfileFormat.svg)

A fix was added to detect if the DIB header contains mask information (according to its size, see [this](https://formats.kaitai.io/bmp/)), and load it accordingly.