### PR TITLE
AVIF/AVIFS support using libavif

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
           build-essential meson pkg-config wayland-protocols
           libwayland-dev libjson-c-dev libxkbcommon-dev
           libfreetype-dev libfontconfig-dev
-          libopenexr-dev libgif-dev libheif-dev libjpeg-dev
-          librsvg2-dev libtiff-dev libwebp-dev
+          libopenexr-dev libgif-dev libheif-dev libavif-dev
+          libjpeg-dev librsvg2-dev libtiff-dev libwebp-dev
 
     - name: Check out source code
       uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ the image directly in a terminal window.
 - SVG (via [librsvg](https://gitlab.gnome.org/GNOME/librsvg));
 - WebP (via [libwebp](https://chromium.googlesource.com/webm/libwebp));
 - HEIF/AVIF (via [libheif](https://github.com/strukturag/libheif));
+- AV1F/AVIFS (via [libavif](https://github.com/AOMediaCodec/libavif));
 - TIFF (via [libtiff](https://libtiff.gitlab.io/libtiff));
 - EXR (via [OpenEXR](https://openexr.com));
 - BMP (built-in);

--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,7 @@ rt = cc.find_library('rt')
 exr = dependency('OpenEXR', version: '>=3.1', required: get_option('exr'))
 gif = cc.find_library('gif', required: get_option('gif'))
 heif = dependency('libheif', required: get_option('heif'))
+avif = dependency('libavif', required: get_option('avif'))
 jpeg = dependency('libjpeg', required: get_option('jpeg'))
 png = dependency('libpng', required: get_option('png'))
 rsvg = dependency('librsvg-2.0', version: '>=2.46', required: get_option('svg'))
@@ -68,6 +69,7 @@ conf = configuration_data()
 conf.set('HAVE_LIBEXR', exr.found())
 conf.set('HAVE_LIBGIF', gif.found())
 conf.set('HAVE_LIBHEIF', heif.found())
+conf.set('HAVE_LIBAVIF', avif.found())
 conf.set('HAVE_LIBJPEG', jpeg.found())
 conf.set('HAVE_LIBJXL', jxl.found())
 conf.set('HAVE_LIBPNG', png.found())
@@ -171,6 +173,9 @@ endif
 if heif.found()
   sources += 'src/formats/heif.c'
 endif
+if avif.found()
+  sources += 'src/formats/avif.c'
+endif
 if jpeg.found()
   sources += 'src/formats/jpeg.c'
 endif
@@ -208,6 +213,7 @@ executable(
     exr,
     gif,
     heif,
+    avif,
     jpeg,
     jxl,
     png,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,6 +11,10 @@ option('heif',
        type: 'feature',
        value: 'auto',
        description: 'Enable HEIF and AVIF format support')
+option('avif',
+       type: 'feature',
+       value: 'auto',
+       description: 'Enable AVIF and AVIFS format support')
 option('jpeg',
        type: 'feature',
        value: 'auto',

--- a/src/formats/avif.c
+++ b/src/formats/avif.c
@@ -31,10 +31,7 @@ static int decode_frame(struct image* ctx, avifDecoder *decoder)
 
     rgb.depth = 8;
     rgb.format = AVIF_RGB_FORMAT_BGRA;
-    rc = avifRGBImageAllocatePixels(&rgb);
-    if (rc != AVIF_RESULT_OK) {
-        goto decode_fail;
-    }
+    avifRGBImageAllocatePixels(&rgb);
 
     rc = avifImageYUVToRGB(decoder->image, &rgb);
     if (rc != AVIF_RESULT_OK) {
@@ -80,10 +77,7 @@ static int decode_frames(struct image* ctx, avifDecoder *decoder)
         rgb.depth = 8;
         rgb.format = AVIF_RGB_FORMAT_BGRA;
 
-        rc = avifRGBImageAllocatePixels(&rgb);
-        if (rc != AVIF_RESULT_OK) {
-            goto decode_fail;
-        }
+        avifRGBImageAllocatePixels(&rgb);
 
         rc = avifImageYUVToRGB(decoder->image, &rgb);
         if (rc != AVIF_RESULT_OK) {

--- a/src/formats/avif.c
+++ b/src/formats/avif.c
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+// AV1 (AVIF/AVIFS) format decoder.
+// Copyright (C) 2023 Artem Senichev <artemsen@gmail.com>
+
+#include "loader.h"
+#include "src/image.h"
+
+#include <avif/avif.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+
+// AVI signature
+static const uint32_t signature = 'f' | 't' << 8 | 'y' << 16 | 'p' << 24;
+#define SIGNATURE_OFFSET 4
+
+static int decode_frame(struct image* ctx, avifDecoder *decoder)
+{
+    avifRGBImage rgb;
+    avifResult rc;
+    struct image_frame* frame;
+
+    rc = avifDecoderNextImage(decoder);
+    if (rc != AVIF_RESULT_OK) {
+        goto decode_fail;
+    }
+
+    memset(&rgb, 0, sizeof(rgb));
+    avifRGBImageSetDefaults(&rgb, decoder->image);
+
+    rgb.depth = 8;
+    rgb.format = AVIF_RGB_FORMAT_BGRA;
+    rc = avifRGBImageAllocatePixels(&rgb);
+    if (rc != AVIF_RESULT_OK) {
+        goto decode_fail;
+    }
+
+    rc = avifImageYUVToRGB(decoder->image, &rgb);
+    if (rc != AVIF_RESULT_OK) {
+        goto fail_pixels;
+    }
+
+    frame = image_create_frame(ctx, decoder->image->width,
+                       decoder->image->height);
+    if (!frame) {
+        goto fail_pixels;
+    }
+
+    memcpy((void*)frame->data, rgb.pixels,
+           rgb.width * rgb.height * sizeof(argb_t));
+
+    avifRGBImageFreePixels(&rgb);
+    return 0;
+
+fail_pixels:
+    avifRGBImageFreePixels(&rgb);
+decode_fail:
+    image_print_error(ctx, "AV1 decode failed: %s", avifResultToString(rc));
+    return -1;
+}
+
+static int decode_frames(struct image* ctx, avifDecoder *decoder)
+{
+    avifImageTiming timing;
+    avifRGBImage rgb;
+    avifResult rc;
+
+    if (!image_create_frames(ctx, decoder->imageCount)) {
+        goto decode_fail;
+    }
+
+    for (size_t i = 0; i < ctx->num_frames; ++i) {
+        rc = avifDecoderNthImage(decoder, i);
+        if (rc != AVIF_RESULT_OK) {
+            goto decode_fail;
+        }
+
+        avifRGBImageSetDefaults(&rgb, decoder->image);
+        rgb.depth = 8;
+        rgb.format = AVIF_RGB_FORMAT_BGRA;
+
+        rc = avifRGBImageAllocatePixels(&rgb);
+        if (rc != AVIF_RESULT_OK) {
+            goto decode_fail;
+        }
+
+        rc = avifImageYUVToRGB(decoder->image, &rgb);
+        if (rc != AVIF_RESULT_OK) {
+            goto fail_pixels;
+        }
+
+        if (!image_frame_allocate(&ctx->frames[i], rgb.width, rgb.height)) {
+            goto fail_pixels;
+        }
+
+        rc = avifDecoderNthImageTiming(decoder, i, &timing);
+        if (rc != AVIF_RESULT_OK) {
+            goto fail_pixels;
+        }
+
+        ctx->frames[i].duration = (size_t)(1000.0f / (float)timing.timescale * (float)timing.durationInTimescales);
+
+        memcpy((void*)ctx->frames[i].data, rgb.pixels,
+               rgb.width * rgb.height * sizeof(argb_t));
+    }
+
+    avifRGBImageFreePixels(&rgb);
+    return 0;
+
+fail_pixels:
+    avifRGBImageFreePixels(&rgb);
+decode_fail:
+    return -1;
+}
+
+// AV1 loader implementation
+enum loader_status decode_avif(struct image* ctx, const uint8_t* data,
+                               size_t size)
+{
+    avifResult rc;
+    avifDecoder* decoder = NULL;
+    int ret;
+
+    // check signature
+    if (size < SIGNATURE_OFFSET + sizeof(signature) ||
+        *(const uint32_t*)(data + SIGNATURE_OFFSET) != signature) {
+        return ldr_unsupported;
+    }
+
+    // open file in decoder
+    decoder = avifDecoderCreate();
+    if (!decoder) {
+        image_print_error(ctx, "unable to create av1 decoder");
+        return ldr_fmterror;
+    }
+    rc = avifDecoderSetIOMemory(decoder, data, size);
+    if (rc != AVIF_RESULT_OK) {
+        goto fail;
+    }
+    rc = avifDecoderParse(decoder);
+    if (rc != AVIF_RESULT_OK) {
+        goto fail;
+    }
+
+    if (decoder->imageCount > 1) {
+        ret = decode_frames(ctx, decoder);
+    } else {
+        ret = decode_frame(ctx, decoder);
+    }
+
+    if (ret != 0) {
+        goto fail;
+    }
+
+    ctx->alpha = decoder->alphaPresent;
+
+    image_set_format(ctx, "AV1 %dbpc %s", decoder->image->depth,
+                   avifPixelFormatToString(decoder->image->yuvFormat));
+
+    avifDecoderDestroy(decoder);
+    return ldr_success;
+
+fail:
+    avifDecoderDestroy(decoder);
+    if (rc != AVIF_RESULT_OK) {
+        image_print_error(ctx, "error decoding av1: %s\n", avifResultToString(rc));
+    }
+    image_free_frames(ctx);
+    return ldr_fmterror;
+}

--- a/src/formats/avif.c
+++ b/src/formats/avif.c
@@ -97,9 +97,10 @@ static int decode_frames(struct image* ctx, avifDecoder *decoder)
 
         memcpy((void*)ctx->frames[i].data, rgb.pixels,
                rgb.width * rgb.height * sizeof(argb_t));
+
+        avifRGBImageFreePixels(&rgb);
     }
 
-    avifRGBImageFreePixels(&rgb);
     return 0;
 
 fail_pixels:

--- a/src/formats/loader.c
+++ b/src/formats/loader.c
@@ -32,6 +32,12 @@ const char* supported_formats = "bmp, pnm"
 #ifdef HAVE_LIBHEIF
                                 ", heif, avif"
 #endif
+#ifdef HAVE_LIBAVIF
+#ifndef HAVE_LIBHEIF
+                                ", avif"
+#endif
+                                ", avifs"
+#endif
 #ifdef HAVE_LIBJXL
                                 ", jxl"
 #endif
@@ -54,6 +60,9 @@ LOADER_DECLARE(gif);
 #endif
 #ifdef HAVE_LIBHEIF
 LOADER_DECLARE(heif);
+#endif
+#ifdef HAVE_LIBAVIF
+LOADER_DECLARE(avif);
 #endif
 #ifdef HAVE_LIBJPEG
 LOADER_DECLARE(jpeg);
@@ -92,6 +101,9 @@ static const image_decoder decoders[] = {
 #endif
 #ifdef HAVE_LIBHEIF
     &LOADER_FUNCTION(heif),
+#endif
+#ifdef HAVE_LIBAVIF
+    &LOADER_FUNCTION(avif),
 #endif
 #ifdef HAVE_LIBRSVG
     &LOADER_FUNCTION(svg),


### PR DESCRIPTION
Libheif does not support animated AV1 files and some options.
This PR adds an optional libavif dependency. avif/avifs decoder is enabled after the heif decoder fails. The decoder supports static and animated images.
;
Здравствуйте, Артем.

Предлагаю добавить в swayimg поддержку анимированных avif-файлов.
Я знаю, что ранее декодер AV1 был удалён в пользу декодера HEIF. Однако, libheif не поддерживает анимацию. Возможно, он не поддерживает еще некоторые бренды AV1, я не проверял.

Данный PR добавляет опциональную зависимость от libavif. Декодер avif/avifs включается после декодера heif и подхватывает те AV1, с которыми последний не справился. Либо работает самостоятельно, если поддержка heif выключена. 
Декодер поддерживает статичные и анимированные картинки.

[Пример анимации](https://ezgif.com/images/format-demo/butterfly.avif)
[Есть набор avif для тестов](https://github.com/link-u/avif-sample-images)

Спасибо за внимание.