### PR TITLE
Fix mouse pan

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -331,7 +331,7 @@ static void on_pointer_motion(void* data, struct wl_pointer* wl_pointer,
     if (ctx.mouse.active) {
         const int dx = x - ctx.mouse.x;
         const int dy = y - ctx.mouse.y;
-        if (dx && dy) {
+        if (dx || dy) {
             viewer_on_drag(dx, dy);
         }
     }


### PR DESCRIPTION
Using integers for coordinates and mouse delta doesn't work because both dx and dy would and up being either -1 or 1, which only allows diagonal panning.

Keep in mind that I only changed the types in the relevant places, and while this compiles fine, I'm pretty sure it's incomplete, please point out anything else this needs.