### PR TITLE
Add timeout option for image info block

### DIFF
--- a/extra/swayimgrc
+++ b/extra/swayimgrc
@@ -75,6 +75,8 @@ shadow = #000000
 [info]
 # Mode on startup (off/brief/full)
 mode = full
+# Hide image information after a timeout (seconds e.g. `5`, or percent of slideshow_time e.g. `50%`)
+timeout = 50%
 # Display scheme for the "full" mode: position = content
 full.topleft = name,format,filesize,imagesize,exif
 full.topright = index

--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -150,6 +150,9 @@ Set startup mode:
 \fIbrief\fR: show brief info;
 \fIoff\fR: don't display any text.
 .\" ----------------------------------------------------------------------------
+.IP "\fBtimeout\fR = \fISECONDS|PERCENT\fR"
+Set timeout of image information displayed on screen. Value is in seconds (e.g. `5`) or in percentage of slideshow_time (e.g. `50%`). `timeout=0` disables the timeout (info block is shown forever). If set as a percentage of the slideshow time, but slideshow is disabled, this timeout will be disabled too. Default is \fI0\fR.
+.\" ----------------------------------------------------------------------------
 .IP "\fBfull.topleft\fR = \fILIST\fR"
 Set display scheme for the \fIfull\fR mode, top left corner of the window.
 \fILIST\fR is a comma delimited list of the following lines:

--- a/src/info.h
+++ b/src/info.h
@@ -6,6 +6,9 @@
 
 #include "font.h"
 
+// Config key for info block timeout
+#define VIEWER_CFG_INFO_TIMEOUT "timeout"
+
 /** Info block position. */
 enum info_position {
     info_top_left,
@@ -69,3 +72,10 @@ size_t info_height(enum info_position pos);
  * @return pointer to the lines array
  */
 const struct info_line* info_lines(enum info_position pos);
+
+/**
+ * Get info display timeout.
+ * @return 0 if timeout disabled, positive number for absolute time in second,
+ * or negative number for slideshow relative percents.
+ */
+int info_timeout(void);

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -76,6 +76,9 @@ struct viewer {
     bool slideshow_enable; ///< Slideshow enable/disable
     int slideshow_fd;      ///< Slideshow timer
     size_t slideshow_time; ///< Slideshow image display time (seconds)
+
+    bool info_timedout; ///< Indicates info block shouldn't be displayed anymore
+    int info_timeout_fd; ///< Info timer
 };
 
 static struct viewer ctx = {
@@ -87,6 +90,8 @@ static struct viewer ctx = {
     .slideshow_enable = false,
     .slideshow_fd = -1,
     .slideshow_time = 3,
+    .info_timedout = false,
+    .info_timeout_fd = -1,
 };
 
 /**
@@ -340,12 +345,30 @@ static void reset_state(void)
     ctx.img_x = 0;
     ctx.img_y = 0;
     ctx.scale = 0;
+    ctx.info_timedout = false;
     scale_image(ctx.scale_init);
     fixup_position(true);
 
     ui_set_title(entry.image->file_name);
     animation_ctl(true);
     slideshow_ctl(ctx.slideshow_enable);
+
+    // Expire info block after timeout
+    const int timeout = info_timeout();
+    if (timeout != 0) {
+        struct itimerspec info_ts = { 0 };
+        if (!ctx.slideshow_enable && timeout < 0) {
+            // If timeout is relative to slideshow, but slideshow is not
+            // enabled, then disable info timeout too
+            info_ts.it_value.tv_sec = 0;
+        } else if (timeout < 0) {
+            // If timeout < 0 => it's relative to slideshow time
+            info_ts.it_value.tv_sec = ctx.slideshow_time * -1 * timeout / 100;
+        } else {
+            info_ts.it_value.tv_sec = timeout;
+        }
+        timerfd_settime(ctx.info_timeout_fd, 0, &info_ts, NULL);
+    }
 }
 
 /**
@@ -405,6 +428,18 @@ static void on_animation_timer(void)
 static void on_slideshow_timer(void)
 {
     slideshow_ctl(next_file(jump_next_file));
+    ui_redraw();
+}
+
+/**
+ * Info block timer event handler.
+ */
+static void on_info_block_timeout(void)
+{
+    // Reset timer to 0, so it won't fire again
+    struct itimerspec info_ts = { 0 };
+    timerfd_settime(ctx.info_timeout_fd, 0, &info_ts, NULL);
+    ctx.info_timedout = true;
     ui_redraw();
 }
 
@@ -588,6 +623,13 @@ void viewer_init(void)
         ui_add_event(ctx.slideshow_fd, on_slideshow_timer);
     }
 
+    // setup info block timer
+    ctx.info_timeout_fd =
+        timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC | TFD_NONBLOCK);
+    if (ctx.info_timeout_fd != -1) {
+        ui_add_event(ctx.info_timeout_fd, on_info_block_timeout);
+    }
+
     // register configuration loader
     config_add_loader(GENERAL_CONFIG_SECTION, load_config);
 }
@@ -602,6 +644,9 @@ void viewer_free(void)
     }
     if (ctx.slideshow_fd != -1) {
         close(ctx.slideshow_fd);
+    }
+    if (ctx.info_timeout_fd != -1) {
+        close(ctx.info_timeout_fd);
     }
 }
 
@@ -628,12 +673,14 @@ void viewer_on_redraw(struct pixmap* window)
     draw_image(window);
 
     // put text info blocks on window surface
-    for (size_t i = 0; i < INFO_POSITION_NUM; ++i) {
-        const size_t lines_num = info_height(i);
-        if (lines_num) {
-            const enum info_position pos = (enum info_position)i;
-            const struct info_line* lines = info_lines(pos);
-            text_print(window, pos, lines, lines_num);
+    if (!ctx.info_timedout) {
+        for (size_t i = 0; i < INFO_POSITION_NUM; ++i) {
+            const size_t lines_num = info_height(i);
+            if (lines_num) {
+                const enum info_position pos = (enum info_position)i;
+                const struct info_line* lines = info_lines(pos);
+                text_print(window, pos, lines, lines_num);
+            }
         }
     }
     if (ctx.help) {


### PR DESCRIPTION
Create a new timer in viewer to hide image info blocks on trigger; when set, image info will be displayed on screen until the timeout expires. When the timeout expires, the UI will redraw and hide info blocks.

The timeout is disabled by default (info block shown forever) but a user may override it to a fixed time (in seconds) or to a percentage of a frame time in slideshow mode (eg if slideshow_time=10 and image_info_timeout=50%, the info block will be hidden after 5 seconds).

## Test in slideshow mode

Before timeout:
![image](https://github.com/artemsen/swayimg/assets/1199441/6e2bbbdf-26f0-4bd4-97c7-4d97388875ec)

After timeout:
![image](https://github.com/artemsen/swayimg/assets/1199441/03412cd2-bea7-458b-b1f1-e2d50c12ea0f)

## Also tested
* non slideshow mode: info block is hidden after timeout, but only when timeout is configured in seconds
* default behaviour: info block is never hidden
* timeout bigger than slideshow time: info block is never hidden