### PR TITLE
allow for translucent colors on window and image backgrounds

### DIFF
--- a/extra/swayimgrc
+++ b/extra/swayimgrc
@@ -28,14 +28,14 @@ antialiasing = no
 # Fix position of the image on the window surface (yes/no)
 fixed = yes
 
-# Background for transparent images (none/grid/RGB, e.g. #112233)
+# Background for transparent images (none/grid/RGB/RGBA, e.g. #112233 or #11223344)
 transparency = grid
 
 # Window position (parent or absolute coordinates, e.g. 100,200)
 position = parent
 # Window size (parent, image, or absolute size, e.g. 800,600)
 size = parent
-# Window background mode/color (none/RGB, e.g. #112233)
+# Window background mode/color (none/RGB/RGBA, e.g. #112233 or #11223344)
 background = none
 
 # Run slideshow at startup (yes/no)

--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -69,7 +69,8 @@ Set background for transparent images:
 .nf
 \fInone\fR: fully transparent, window color will be use;
 \fIgrid\fR: draw chessboard (default);
-\fI#COLOR\fR: solid RGB color in hex format, e.g `#102030`.
+\fI#COLOR\fR: solid RGB color in hex format, e.g `#102030`;
+\fI#COLOR\fR: RGBA color in hex format, e.g `#10203040`.
 .\" ----------------------------------------------------------------------------
 .IP "\fBposition\fR = \fI[MODE|COORDINATES]\fR"
 Set initial position of the window (Sway only):
@@ -87,7 +88,8 @@ Set initial size of the window:
 .IP "\fBbackground\fR = \fI[MODE|#COLOR]\fR"
 Set window background:
 \fInone\fR: transparent window (default);
-\fI#COLOR\fR: solid RGB color in hex format, e.g `#102030`.
+\fI#COLOR\fR: solid RGB color in hex format, e.g `#102030`;
+\fI#COLOR\fR: RGBA color in hex format, e.g `#10203040`.
 .\" ----------------------------------------------------------------------------
 .IP "\fBslideshow\fR = \fI[yes|no]\fR"
 Run slideshow at startup, \fIno\fR by default.

--- a/src/config.c
+++ b/src/config.c
@@ -4,6 +4,7 @@
 
 #include "config.h"
 
+#include "src/pixmap.h"
 #include "str.h"
 
 #include <ctype.h>
@@ -297,6 +298,30 @@ bool config_to_color(const char* text, argb_t* color)
     }
 
     if (str_to_num(text, 0, &num, 16) && num >= 0 && num <= 0xffffffff) {
+        *color = num;
+        return true;
+    }
+
+    return false;
+}
+
+bool config_to_translucent_color(const char* text, argb_t* color)
+{
+    ssize_t num;
+
+    if (*text == '#') {
+        ++text;
+    }
+
+    if (str_to_num(text, 0, &num, 16) && num >= 0 && num <= 0xffffffff) {
+        if (num > 0x00ffffff) {
+            ssize_t alpha = 0x000000ff & num;  // extract alpha
+            num >>= 8;                         // shift r, g, and b into expected position
+            num |= ARGB_SET_A(alpha);          // recompose
+        } else {
+            num |= ARGB_SET_A(0xff);
+        }
+
         *color = num;
         return true;
     }

--- a/src/config.h
+++ b/src/config.h
@@ -65,9 +65,17 @@ void config_add_loader(const char* section, config_loader loader);
 bool config_to_bool(const char* text, bool* flag);
 
 /**
- * Convert text value to ARGB color.
+ * Convert text value to ARGB color, with a constant max value for alpha.
  * @param text text to convert
  * @param color output variable
  * @return false if text has invalid format
  */
 bool config_to_color(const char* text, argb_t* color);
+
+/**
+ * Convert text value to ARGB color which may be any alpha.
+ * @param text text to convert
+ * @param color output variable
+ * @return false if text has invalid format
+ */
+bool config_to_translucent_color(const char* text, argb_t* color);


### PR DESCRIPTION
Allows for colors in the format `#RRGGBBAA` in addition to the already permitted `#RRGGBB` for window and transparent image backgrounds. This change makes the `none` config option exactly equivilent to `#00000000`, and both are acceptable - this PR does not (to my knowledge) make any breaking changes. This format is disallowed for other config options still.

Implemented via a slightly modified `config_to_color` function called `config_to_translucent_color`, which will make the numeric conversion from hex to a 32 bit integer as usual, then masks out the alpha and shifts some bits to match the format of `argb_t` if the input string is longer than 6 characters.

Since the alpha channel was used for a sentinal value indicating a grid background for images - the indication of this option is now a `bool` in `viewer.c`'s `viewer` struct.

Am happy to hear feedback in case any changes are sub-optimal or have a prefered alternative - thanks!