### PR TITLE
Add interface to create image context from memory

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -140,6 +140,11 @@ done:
     return ctx;
 }
 
+struct image* image_create_from_memory(const uint8_t* data, size_t size)
+{
+    return image_create(MEM_FILE_NAME, data, size);
+}
+
 void image_free(struct image* ctx)
 {
     if (ctx) {

--- a/src/image.h
+++ b/src/image.h
@@ -37,6 +37,9 @@ struct image_info {
 /** Name used for image, that is read from stdin through pipe. */
 #define STDIN_FILE_NAME "{STDIN}"
 
+/** Name used for image that is read directly from memory. */
+#define MEM_FILE_NAME "{MEM}"
+
 /**
  * Load image from file.
  * @param file path to the file to load
@@ -49,6 +52,12 @@ struct image* image_from_file(const char* file);
  * @return image context or NULL on errors
  */
 struct image* image_from_stdin(void);
+
+/**
+ * Load image from an arbitrary memory location.
+ * @return image context or NULL on errors
+ */
+struct image* image_create_from_memory(const uint8_t* data, size_t size);
 
 /**
  * Free image.


### PR DESCRIPTION
Exposing this function enables users hacking Swayimg to implement their own image-to-memory loader (eg from curl) while keeping the standard image loader from upstream.