### PR TITLE
Disable antialiasing while dragging

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -347,6 +347,7 @@ static void on_pointer_button(void* data, struct wl_pointer* wl_pointer,
     if (button == BTN_LEFT) {
         ctx.mouse.active = (state == WL_POINTER_BUTTON_STATE_PRESSED);
     }
+    ui_redraw();
 }
 
 static void on_pointer_axis(void* data, struct wl_pointer* wl_pointer,

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -880,12 +880,15 @@ void viewer_on_drag(int dx, int dy)
 {
     const ssize_t old_x = ctx.img_x;
     const ssize_t old_y = ctx.img_y;
+    const bool aa = ctx.antialiasing;
 
     ctx.img_x += dx;
     ctx.img_y += dy;
 
     if (ctx.img_x != old_x || ctx.img_y != old_y) {
+        ctx.antialiasing = false;
         fixup_position(false);
         ui_redraw();
+        ctx.antialiasing = aa;
     }
 }


### PR DESCRIPTION
While the left mouse button is pressed down antialiasing is now disabled.

Reason: Dragging while antialiasing is enabled is unusable on some machines.