### PR TITLE
Fix 1.0 scale

### DIFF
--- a/src/viewer.c
+++ b/src/viewer.c
@@ -595,7 +595,7 @@ static void draw_image(struct pixmap* wnd)
     }
 
     // put image on window surface
-    if (ctx.scale == 1.0) {
+    if (ctx.scale == 1.0 && ctx.img_y == 0 && ctx.img_x == 0) {
         pixmap_copy(img_pm, wnd, ctx.img_x, ctx.img_y, img->alpha);
     } else if (ctx.antialiasing) {
         pixmap_scale_bicubic(img_pm, wnd, ctx.img_x, ctx.img_y, ctx.scale,


### PR DESCRIPTION
Previously pixman_copy was used when the image was scaled 1 to 1. Easiest way to see what's wrong with that is when viewing an image with the resolution of the display in fullscreen and moving the image up or left.