### PR TITLE
Fix warnings on 32-bit platforms

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -119,7 +119,7 @@ static bool load_config(const char* path)
             ++line;
             delim = strchr(line, ']');
             if (!delim || line + 1 == delim) {
-                fprintf(stderr, "Invalid section define in %s:%lu\n", path,
+                fprintf(stderr, "Invalid section define in %s:%zu\n", path,
                         line_num);
                 continue;
             }
@@ -132,7 +132,7 @@ static bool load_config(const char* path)
 
         delim = strchr(line, '=');
         if (!delim) {
-            fprintf(stderr, "Invalid key=value format in %s:%lu\n", path,
+            fprintf(stderr, "Invalid key=value format in %s:%zu\n", path,
                     line_num);
             continue;
         }
@@ -151,7 +151,7 @@ static bool load_config(const char* path)
         // load configuration parameter from key/value pair
         status = config_set(section, line, value);
         if (status != cfgst_ok) {
-            fprintf(stderr, "Invalid configuration in %s:%lu\n", path,
+            fprintf(stderr, "Invalid configuration in %s:%zu\n", path,
                     line_num);
         }
     }
@@ -299,7 +299,8 @@ bool config_to_color(const char* text, argb_t* color)
         ++text;
     }
 
-    if (!str_to_num(text, 0, &num, 16) || num < 0 || num > 0xffffffff) {
+    if (!str_to_num(text, 0, &num, 16) || num < 0 ||
+        (uint64_t)num > (uint64_t)0xffffffff) {
         return false;
     }
 

--- a/src/info.c
+++ b/src/info.c
@@ -397,14 +397,14 @@ void info_update(size_t frame_idx, float scale)
         (ctx.frame != frame_idx || ctx.frame_total != image->num_frames)) {
         ctx.frame = frame_idx;
         ctx.frame_total = image->num_frames;
-        snprintf(buffer, sizeof(buffer), "%lu of %lu", ctx.frame + 1,
+        snprintf(buffer, sizeof(buffer), "%zu of %zu", ctx.frame + 1,
                  ctx.frame_total);
         update_field(buffer, &ctx.fields[info_frame].value);
     }
 
     if (is_visible(info_index) && ctx.index != loader_current_index()) {
         ctx.index = loader_current_index();
-        snprintf(buffer, sizeof(buffer), "%lu of %lu", ctx.index + 1,
+        snprintf(buffer, sizeof(buffer), "%zu of %zu", ctx.index + 1,
                  image_list_size());
         update_field(buffer, &ctx.fields[info_index].value);
     }
@@ -413,7 +413,7 @@ void info_update(size_t frame_idx, float scale)
         const size_t scale_percent = scale * 100;
         if (ctx.scale != scale_percent) {
             ctx.scale = scale_percent;
-            snprintf(buffer, sizeof(buffer), "%ld%%", ctx.scale);
+            snprintf(buffer, sizeof(buffer), "%zu%%", ctx.scale);
             update_field(buffer, &ctx.fields[info_scale].value);
         }
     }
@@ -423,7 +423,7 @@ void info_update(size_t frame_idx, float scale)
         if (ctx.width != pm->width || ctx.height != pm->height) {
             ctx.width = pm->width;
             ctx.height = pm->height;
-            snprintf(buffer, sizeof(buffer), "%lux%lu", ctx.width, ctx.height);
+            snprintf(buffer, sizeof(buffer), "%zux%zu", ctx.width, ctx.height);
             update_field(buffer, &ctx.fields[info_image_size].value);
         }
     }

--- a/src/ui.c
+++ b/src/ui.c
@@ -157,8 +157,8 @@ static struct wl_buffer* create_buffer(void)
 
     // generate unique file name
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    snprintf(path, sizeof(path), "/" APP_NAME "_%lx",
-             (ts.tv_sec << 32) | ts.tv_nsec);
+    snprintf(path, sizeof(path), "/" APP_NAME "_%" PRIx64,
+             ((uint64_t)ts.tv_sec << 32) | ts.tv_nsec);
 
     // open shared mem
     fd = shm_open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
@@ -698,8 +698,8 @@ void ui_create(void)
     // create unique application id
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
         char app_id[64];
-        const uint64_t timestamp = (ts.tv_sec << 32) | ts.tv_nsec;
-        snprintf(app_id, sizeof(app_id), APP_NAME "_%lx", timestamp);
+        const uint64_t timestamp = ((uint64_t)ts.tv_sec << 32) | ts.tv_nsec;
+        snprintf(app_id, sizeof(app_id), APP_NAME "_%" PRIx64, timestamp);
         str_dup(app_id, &ctx.app_id);
     } else {
         str_dup(APP_NAME, &ctx.app_id);

--- a/src/ui.h
+++ b/src/ui.h
@@ -6,6 +6,8 @@
 
 #include "pixmap.h"
 
+#include <limits.h>
+
 // Configuration parameters
 #define UI_CFG_APP_ID     "app_id"
 #define UI_CFG_FULLSCREEN "fullscreen"
@@ -15,7 +17,7 @@
 // Special ids for windows size and position
 #define SIZE_FROM_IMAGE  0
 #define SIZE_FROM_PARENT 1
-#define POS_FROM_PARENT  0xffffffff
+#define POS_FROM_PARENT  SSIZE_MAX
 
 /**
  * Create User Interface context.


### PR DESCRIPTION
Fixed code that assumed the size of some integer types to be a fixed number of bytes, when it can very between platforms. The warnings fixed were:

 - Wrong `printf` formats for `size_t`. Now, the platform-independent `%zu` (C99 required);
 - `time_t` may be less than 64 bits, requiring a cast to a bigger size if a left shift by 32 bits is used.
 - `POS_FROM_PARENT` may assume a value too large for `ssize_t`.

I didn't test if these warnings caused any runtime errors, but they can do so, so it's better to have them fixed.