### PR TITLE
feat: `wp_content_type_v1` protocol support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -119,6 +119,21 @@ xdg_shell_h = custom_target(
   command: [wl_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
 )
 
+# wp_content_type_v1 Wayland protocol
+wp_content_type_v1_xml = wlproto_dir / 'staging/content-type/content-type-v1.xml'
+wp_content_type_v1_c = custom_target(
+  'wp-content-type-v1-protocol.c',
+  output: 'wp-content-type-v1-protocol.c',
+  input: wp_content_type_v1_xml,
+  command: [wl_scanner, 'private-code', '@INPUT@', '@OUTPUT@']
+)
+wp_content_type_v1_h = custom_target(
+  'wp-content-type-v1-protocol.h',
+  output: 'wp-content-type-v1-protocol.h',
+  input: wp_content_type_v1_xml,
+  command: [wl_scanner, 'client-header', '@INPUT@', '@OUTPUT@']
+)
+
 # install sample config
 install_data('extra/swayimgrc', install_dir: get_option('datadir') / 'swayimg')
 
@@ -194,6 +209,8 @@ sources = [
   'src/formats/tga.c',
   xdg_shell_h,
   xdg_shell_c,
+  wp_content_type_v1_h,
+  wp_content_type_v1_c,
 ]
 if exif.found()
   sources += 'src/exif.c'


### PR DESCRIPTION
The `wp_content_type_v1` protocol allow the Wayland client to describe the kind of content a surface will display, to allow the compositor to optimize its behavior for it.

See
- https://wayland.app/protocols/content-type-v1
- https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/117

Implementation here sets the content type to `PHOTO`, only if the compositor advertises this protocol, otherwise, log nothing to the user.