### PR TITLE
Fix cache indexing out-of-bounds

### DIFF
--- a/src/fetcher.c
+++ b/src/fetcher.c
@@ -150,7 +150,7 @@ static void cache_trim(struct image_cache* cache, size_t size)
     if (size == 0) {
         cache_reset(cache);
     } else {
-        for (size_t i = cache->capacity - 1; i > size; ++i) {
+        for (size_t i = cache->capacity - 1; i > size; --i) {
             image_free(cache->queue[i]);
             cache->queue[i] = NULL;
         }


### PR DESCRIPTION
Next image and previous image commands in viewer mode segfaults when insufficient amount of images exist (specifically when `size_t size` in `cache_trim` is less than `cache->capacity - 1`).