### PR TITLE
Support single file external compression

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,9 @@ tiff = dependency('libtiff-4', required: get_option('tiff'))
 webp = dependency('libwebp', required: get_option('webp'))
 webp_demux = dependency('libwebpdemux', required: get_option('webp'))
 
+# optional dependencies: compression formats support
+bzip2 = dependency('bzip2', required: get_option('bzip2'))
+
 # hack to build "pkgconfigless" gif in FreeBSD
 gif_opt = get_option('gif')
 if gif_opt.disabled()
@@ -90,6 +93,7 @@ conf.set('HAVE_LIBTIFF', tiff.found())
 conf.set('HAVE_LIBWEBP', webp.found() and webp_demux.found())
 conf.set('HAVE_LIBEXIF', exif.found())
 conf.set('HAVE_INOTIFY', cc.has_header('sys/inotify.h', dependencies: inotify))
+conf.set('HAVE_LIBBZ2', bzip2.found())
 conf.set_quoted('APP_NAME', meson.project_name())
 conf.set_quoted('APP_VERSION', version)
 configure_file(output: 'buildcfg.h', configuration: conf)
@@ -245,6 +249,9 @@ endif
 if webp.found() and webp_demux.found()
   sources += 'src/formats/webp.c'
 endif
+if bzip2.found()
+  sources += 'src/formats/bzip2.c'
+endif
 
 executable(
   'swayimg',
@@ -272,6 +279,8 @@ executable(
     rsvg,
     tiff,
     webp, webp_demux,
+    # compression support
+    bzip2,
   ],
   install: true
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -40,6 +40,12 @@ option('webp',
        value: 'auto',
        description: 'Enable WebP format support')
 
+# compression support
+option('bzip2',
+       type: 'feature',
+       value: 'auto',
+       description: 'Enable Bzip2 compression support')
+
 # EXIF support
 option('exif',
        type: 'feature',

--- a/src/formats/bzip2.c
+++ b/src/formats/bzip2.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// PNM formats decoder
+// Copyright (C) 2023 Abe Wieland <abe.wieland@gmail.com>
+
+#include "../loader.h"
+
+#include <limits.h>
+#include <bzlib.h>
+#include <stdlib.h>
+
+enum loader_status decode_bz2(struct image* ctx, const uint8_t* data,
+                              size_t size)
+{
+    unsigned int decsize = 2 * (unsigned int) size;
+    char* decdata = (char*)malloc(sizeof(char) * (int) decsize);
+    while ( true ) {
+        switch (BZ2_bzBuffToBuffDecompress(decdata, &decsize, (char *) data, (unsigned int) size, 0, 0)){
+            case BZ_MEM_ERROR:
+                free(decdata);
+                if ( decsize > INT_MAX/2 ) return ldr_fmterror;
+                decsize*=2;
+                decdata = (char*)malloc(sizeof(char) * (int) decsize);
+                continue;
+            case BZ_DATA_ERROR_MAGIC:
+                free(decdata);
+                return ldr_unsupported;
+            case BZ_OK:
+                break;
+            default:
+                free(decdata);
+                return ldr_fmterror;
+        }
+        break;
+    }
+    enum loader_status recursive_status = recur_loader(ctx, (const uint8_t *) decdata, (size_t) decsize);
+    if ( recursive_status != ldr_success ) return recursive_status;
+    image_set_format(ctx, ctx->format, "+bzip2");
+    return ldr_success;
+}

--- a/src/loader.c
+++ b/src/loader.c
@@ -100,6 +100,9 @@ LOADER_DECLARE(tiff);
 #ifdef HAVE_LIBWEBP
 LOADER_DECLARE(webp);
 #endif
+#ifdef HAVE_LIBBZ2
+LOADER_DECLARE(bz2);
+#endif
 
 // list of available decoders
 static const image_decoder decoders[] = {
@@ -133,6 +136,9 @@ static const image_decoder decoders[] = {
 #endif
 #ifdef HAVE_LIBTIFF
     &LOADER_FUNCTION(tiff),
+#endif
+#ifdef HAVE_LIBBZ2
+    &LOADER_FUNCTION(bz2),
 #endif
     &LOADER_FUNCTION(qoi),  &LOADER_FUNCTION(tga),
 };
@@ -435,4 +441,8 @@ void loader_queue_reset(void)
     pthread_cond_signal(&ctx.signal);
     pthread_cond_wait(&ctx.ready, &ctx.lock);
     pthread_mutex_unlock(&ctx.lock);
+}
+
+enum loader_status recur_loader (struct image* ctx, const uint8_t* data, size_t size){
+	return image_from_memory(ctx, data, size);
 }

--- a/src/loader.h
+++ b/src/loader.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "image.h"
+#include <stdint.h>
+#include <tiff.h>
 
 // File name used for image, that is read from stdin through pipe
 #define LDRSRC_STDIN     "stdin://"
@@ -71,3 +73,10 @@ void loader_queue_append(size_t index);
  * Reset background loader queue.
  */
 void loader_queue_reset(void);
+
+/**
+ * Recur the image loader
+ * Only to be used for decompression
+ */
+
+enum loader_status recur_loader (struct image*, const uint8_t* data, size_t size);

--- a/test/meson.build
+++ b/test/meson.build
@@ -55,6 +55,9 @@ endif
 if webp.found() and webp_demux.found()
   sources += '../src/formats/webp.c'
 endif
+if bzip2.found()
+  sources += '../src/formats/bzip2.c'
+endif
 
 test(
   'swayimg',
@@ -75,7 +78,7 @@ test(
       png,
       rsvg,
       tiff,
-      webp, webp_demux,
+      webp, webp_demux, bzip2
     ],
     include_directories: '../src',
     cpp_args : '-DTEST_DATA_DIR="' + meson.current_source_dir() + '/data"',


### PR DESCRIPTION
Support single file external compression (ex. `foo.pnm.gz`, `foo.png.xz`.

This can be done by adding a recursive step to the decoder logic. Reference implementation using bzip2.

Related to #216 