### PR TITLE
Automatic generation of exec entries based of file exntension

### DIFF
--- a/src/imagelist.h
+++ b/src/imagelist.h
@@ -8,10 +8,12 @@
 
 // Configuration parameters
 #define IMGLIST_SECTION   "list"
+#define IMGLIST_AUTOEXEC  "list.autoexec"
 #define IMGLIST_ORDER     "order"
 #define IMGLIST_LOOP      "loop"
 #define IMGLIST_RECURSIVE "recursive"
 #define IMGLIST_ALL       "all"
+#define AUTOEXEC_FORMATS  "formats"
 
 // Invalid index of the entry
 #define IMGLIST_INVALID SIZE_MAX


### PR DESCRIPTION
This allows the user to set an exec rule that would be executed automatically when a file with a specified extension is opened by Swayimg.

Ex.
```
[listl.autoexec]
formats = mp4,eps
mp4 = ffmpegthumbnailer -i % -o - -c png
eps = inkscape % --export-filename=- --export-type=svg
```

In this example, every time the user tries to open a `foo.mp4` time, swayimg will automatically invoke ffmpegthumbnailer, and every time the user tries to open a `foo.eps` file, swayimg will automatically invoke Inkscape to convert it to svg.

This may have uses beyond just hacking in support for formats swayimg has no decoder for.