### PR TITLE
Small cleanup

### DIFF
--- a/src/application.c
+++ b/src/application.c
@@ -402,7 +402,7 @@ bool app_init(struct config* cfg, const char** sources, size_t num)
         ui_toggle_fullscreen();
     } else if (ctx.window.width == SIZE_FROM_IMAGE ||
                ctx.window.width == SIZE_FROM_PARENT) {
-        // fixup window size form the first image
+        // determine window size from the first image
         const struct pixmap* pm = &first_image->frames[0].pm;
         ctx.window.width = pm->width;
         ctx.window.height = pm->height;

--- a/src/font.c
+++ b/src/font.c
@@ -6,7 +6,7 @@
 
 #include "memdata.h"
 
-// font realted
+// font related
 #include <fontconfig/fontconfig.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H

--- a/src/formats/png.c
+++ b/src/formats/png.c
@@ -35,7 +35,7 @@ static void png_reader(png_structp png, png_bytep buffer, size_t size)
  */
 static png_bytep* bind_pixmap(const struct pixmap* pm)
 {
-    png_bytep* ptr = malloc(pm->height * sizeof(png_bytep));
+    png_bytep* ptr = malloc(pm->height * sizeof(*ptr));
 
     if (ptr) {
         for (uint32_t i = 0; i < pm->height; ++i) {

--- a/src/formats/pnm.c
+++ b/src/formats/pnm.c
@@ -6,9 +6,10 @@
 
 #include <limits.h>
 
-// Divide a by b, rounding to the nearest integer; evaluates b twice
+// Both assume positive arguments and evaluate b more than once
+// Divide, rounding to nearest (up on ties)
 #define div_near(a, b) (((a) + (b) / 2) / (b))
-// Divide a by b, rounding up; evaluates b twice
+// Divide, rounding up
 #define div_ceil(a, b) (((a) + (b) - 1) / (b))
 
 // PNM file types

--- a/src/gallery.c
+++ b/src/gallery.c
@@ -13,25 +13,25 @@
 #include <stdlib.h>
 
 // Configuration parameters
-#define CFG_SECTION    "gallery"
-#define CFG_SIZE       "size"
-#define CFG_SIZE_DEF   200
-#define CFG_CACHE      "cache"
-#define CFG_CACHE_DEF  100
-#define CFG_FILL       "fill"
-#define CFG_FILL_DEF   true
-#define CFG_WINDOW     "window"
-#define CFG_WINDOW_DEF ARGB(0, 0, 0, 0)
-#define CFG_BACKGR     "background"
-#define CFG_BACKGR_DEF ARGB(0xff, 0x20, 0x20, 0x20)
-#define CFG_SELECT     "select"
-#define CFG_SELECT_DEF ARGB(0xff, 0x40, 0x40, 0x40)
-#define CFG_BORDER     "border"
-#define CFG_BORDER_DEF ARGB(0xff, 0, 0, 0)
-#define CFG_SHADOW     "shadow"
-#define CFG_SHADOW_DEF ARGB(0xff, 0, 0, 0)
-#define CFG_AA         "antialiasing"
-#define CFG_AA_DEF     false
+#define CFG_SECTION          "gallery"
+#define CFG_SIZE             "size"
+#define CFG_SIZE_DEF         200
+#define CFG_CACHE            "cache"
+#define CFG_CACHE_DEF        100
+#define CFG_FILL             "fill"
+#define CFG_FILL_DEF         true
+#define CFG_ANTIALIASING     "antialiasing"
+#define CFG_ANTIALIASING_DEF false
+#define CFG_WINDOW           "window"
+#define CFG_WINDOW_DEF       ARGB(0, 0, 0, 0)
+#define CFG_BACKGROUND       "background"
+#define CFG_BACKGROUND_DEF   ARGB(0xff, 0x20, 0x20, 0x20)
+#define CFG_SELECT           "select"
+#define CFG_SELECT_DEF       ARGB(0xff, 0x40, 0x40, 0x40)
+#define CFG_BORDER           "border"
+#define CFG_BORDER_DEF       ARGB(0xff, 0, 0, 0)
+#define CFG_SHADOW           "shadow"
+#define CFG_SHADOW_DEF       ARGB(0xff, 0, 0, 0)
 
 // Scale for selected thumbnail
 #define THUMB_SELECTED_SCALE 1.15f
@@ -49,7 +49,7 @@ struct gallery {
     size_t thumb_max;         ///< Max number of thumbnails in cache
     struct thumbnail* thumbs; ///< List of preview images
     bool thumb_fill;          ///< Scale mode (fill/fit)
-    bool thumb_aa;            ///< Use anti-aliasing for thumbnail
+    bool antialiasing;        ///< Use anti-aliasing for thumbnails
 
     argb_t clr_window;     ///< Window background
     argb_t clr_background; ///< Tile background
@@ -77,7 +77,7 @@ static void add_thumbnail(struct image* image)
         entry->width = image->frames[0].pm.width;
         entry->height = image->frames[0].pm.height;
         entry->image = image;
-        image_thumbnail(image, ctx.thumb_size, ctx.thumb_fill, ctx.thumb_aa);
+        image_thumbnail(image, ctx.thumb_size, ctx.thumb_fill, ctx.antialiasing);
         ctx.thumbs = list_append(ctx.thumbs, entry);
     }
 }
@@ -169,7 +169,7 @@ static void reset_loader(void)
         }
     }
 
-    // remove the furthest thumnails from the cache
+    // remove the furthest thumbnails from the cache
     if (ctx.thumb_max != 0 && total < ctx.thumb_max) {
         const size_t half = (ctx.thumb_max - total) / 2;
         const size_t min_id = image_list_jump(ctx.top, half, false);
@@ -185,7 +185,7 @@ static void reset_loader(void)
     }
 }
 
-/** Update thumnails layout. */
+/** Update thumbnail layout. */
 static void update_layout(void)
 {
     size_t cols, rows;
@@ -395,7 +395,7 @@ static void draw_thumbnail(struct pixmap* window, ssize_t x, ssize_t y,
             const ssize_t thumb_h = thumb->height * THUMB_SELECTED_SCALE;
             const ssize_t tx = x + thumb_size / 2 - thumb_w / 2;
             const ssize_t ty = y + thumb_size / 2 - thumb_h / 2;
-            pixmap_scale(ctx.thumb_aa ? pixmap_bicubic : pixmap_nearest, thumb,
+            pixmap_scale(ctx.antialiasing ? pixmap_bicubic : pixmap_nearest, thumb,
                          window, tx, ty, THUMB_SELECTED_SCALE, image->alpha);
         }
 
@@ -442,7 +442,7 @@ static void draw_thumbnails(struct pixmap* window)
     ssize_t select_y = 0;
     const struct thumbnail* select_th = NULL;
 
-    // thumbnails layout
+    // thumbnail layout
     get_layout(&cols, &rows, &gap);
     ++rows;
 
@@ -509,7 +509,7 @@ static void apply_action(const struct action* action)
 {
     switch (action->type) {
         case action_antialiasing:
-            ctx.thumb_aa = !ctx.thumb_aa;
+            ctx.antialiasing = !ctx.antialiasing;
             clear_thumbnails();
             reset_loader();
             app_redraw();
@@ -581,11 +581,12 @@ void gallery_init(struct config* cfg, struct image* image)
     ctx.thumb_max =
         config_get_num(cfg, CFG_SECTION, CFG_CACHE, 0, 1024, CFG_CACHE_DEF);
     ctx.thumb_fill = config_get_bool(cfg, CFG_SECTION, CFG_FILL, CFG_FILL_DEF);
-    ctx.thumb_aa = config_get_bool(cfg, CFG_SECTION, CFG_AA, CFG_AA_DEF);
+    ctx.antialiasing = config_get_bool(cfg, CFG_SECTION, CFG_ANTIALIASING,
+                                       CFG_ANTIALIASING_DEF);
     ctx.clr_window =
         config_get_color(cfg, CFG_SECTION, CFG_WINDOW, CFG_WINDOW_DEF);
     ctx.clr_background =
-        config_get_color(cfg, CFG_SECTION, CFG_BACKGR, CFG_BACKGR_DEF);
+        config_get_color(cfg, CFG_SECTION, CFG_BACKGROUND, CFG_BACKGROUND_DEF);
     ctx.clr_select =
         config_get_color(cfg, CFG_SECTION, CFG_SELECT, CFG_SELECT_DEF);
     ctx.clr_border =

--- a/src/info.c
+++ b/src/info.c
@@ -339,7 +339,7 @@ static void import_exif(const struct image* image)
     struct keyval* line;
     const size_t buf_size = image->num_info * sizeof(*line);
 
-    // free previuos lines
+    // free previous lines
     for (size_t i = 0; i < ctx.exif_num; ++i) {
         free(ctx.exif_lines[i].key.data);
         free(ctx.exif_lines[i].value.data);

--- a/src/main.c
+++ b/src/main.c
@@ -138,7 +138,7 @@ static int parse_cmdargs(int argc, char* argv[], struct config** cfg)
             case 'c':
                 if (!config_set_arg(cfg, optarg)) {
                     fprintf(stderr,
-                            "WARNING: Invalid config agrument: \"%s\"\n",
+                            "WARNING: Invalid config argument: \"%s\"\n",
                             optarg);
                 }
                 break;

--- a/src/memdata.h
+++ b/src/memdata.h
@@ -98,7 +98,7 @@ char* str_append(const char* src, size_t len, char** dst);
 bool str_to_num(const char* text, size_t len, ssize_t* value, int base);
 
 /**
- * Convert ansi string to wide char format.
+ * Convert ASCII string to wide char format.
  * @param src source string to encode
  * @param dst pointer to destination buffer
  * @return pointer to wide string, caller must free it

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -553,7 +553,7 @@ void pixmap_scale(enum pixmap_scale scaler, const struct pixmap* src,
 
     // create task for each CPU core
     if (threads_num) {
-        tasks = malloc(threads_num * sizeof(struct scale_task));
+        tasks = malloc(threads_num * sizeof(*tasks));
         if (!tasks) {
             return;
         }
@@ -626,7 +626,7 @@ void pixmap_rotate(struct pixmap* pm, size_t angle)
             *color2 = swap;
         }
     } else if (angle == 90 || angle == 270) {
-        argb_t* data = malloc(pm->height * pm->width * sizeof(argb_t));
+        argb_t* data = malloc(pm->height * pm->width * sizeof(*data));
         if (data) {
             const size_t width = pm->height;
             const size_t height = pm->width;


### PR DESCRIPTION
Add consistency between the gallery and viewer configs, fix some spelling mistakes, use clamp instead of a mix of min and max for clarity, and ensure all calls to malloc with a sizeof use the variable itself to make future changes to types easier.