### PR TITLE
Offset window position and size according to sway border thickness

### DIFF
--- a/src/application.c
+++ b/src/application.c
@@ -76,7 +76,7 @@ static struct application ctx;
 /**
  * Setup window position via Sway IPC.
  */
-static void sway_setup(void)
+static void sway_setup(const struct config* cfg)
 {
     struct wndrect parent;
     bool fullscreen;
@@ -87,7 +87,7 @@ static void sway_setup(void)
     if (ipc == INVALID_SWAY_IPC) {
         return; // sway not available
     }
-    if (!sway_current(ipc, &parent, &fullscreen)) {
+    if (!sway_current(ipc, &parent, &fullscreen, cfg)) {
         sway_disconnect(ipc);
         return;
     }
@@ -403,7 +403,7 @@ bool app_init(const struct config* cfg, const char** sources, size_t num)
 
     // setup window position and size
     if (ctx.window.width != SIZE_FULLSCREEN) {
-        sway_setup(); // try Sway integration
+        sway_setup(cfg); // try Sway integration
     }
     if (ctx.window.width == SIZE_FULLSCREEN) {
         ui_toggle_fullscreen();

--- a/src/sway.h
+++ b/src/sway.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "config.h"
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <sys/types.h>
@@ -37,7 +39,7 @@ void sway_disconnect(int ipc);
  * @param fullscreen current full screen mode
  * @return true if operation completed successfully
  */
-bool sway_current(int ipc, struct wndrect* wnd, bool* fullscreen);
+bool sway_current(int ipc, struct wndrect* wnd, bool* fullscreen, const struct config* cfg);
 
 /**
  * Add rules for Sway for application's window:


### PR DESCRIPTION
First of all, this is my first PR ever, I apologise for any errors.

So the problem I encountered was that when I open an image, the application window is wrongly offset by the thickness of my sway borders.

Relevant configuration to reproduce the problem:

- Enable sway borders, together with smart borders
- Enable swayimg window decorations
- Open any image.

Image of the problem (I have set sway borders to 32px thick to easier display the problem):
![bild](https://github.com/user-attachments/assets/a5d04e8b-235b-42b2-97d2-32b228700a57)
![bild](https://github.com/user-attachments/assets/8cb1b31e-6aab-4588-a5f4-214f46324f7d)

In a non-floating window:
![bild](https://github.com/user-attachments/assets/eb3dabc2-4497-4fa4-9aae-8e4ff51a1f02)

My PR fixes this. I have tested all four combinations of smart border on or off and swayimg's window decoration on or off.

I am by far not a C programmer, but I have done my best to respect your source code. I have also written some comments in the code that are only for better explaining this PR, feel free to remove them.
