### PR TITLE
Add numeric sort order

### DIFF
--- a/extra/swayimg.1
+++ b/extra/swayimg.1
@@ -42,6 +42,7 @@ Set order of the image list:
 .nf
 \fInone\fR: unsorted, order is system depended;
 \fIalpha\fR: sorted alphabetically (default);
+\fInumeric\fR: sorted numerically;
 \fImtime\fR: sorted by file modification time;
 \fIsize\fR: sorted by file size;
 \fIrandom\fR: randomize list.

--- a/extra/swayimgrc
+++ b/extra/swayimgrc
@@ -87,7 +87,7 @@ shadow = #000000ff
 # Image list configuration
 ################################################################################
 [list]
-# Default order (none/alpha/mtime/size/random)
+# Default order (none/alpha/numeric/mtime/size/random)
 order = alpha
 # Reverse order (yes/no)
 reverse = no

--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -191,6 +191,7 @@ Set order of the image list:
 .nf
 \fInone\fR: unsorted, order is system depended;
 \fIalpha\fR: sorted alphabetically (default);
+\fInumeric\fR: sorted numerically;
 \fImtime\fR: sorted by file modification time;
 \fIsize\fR: sorted by file size;
 \fIrandom\fR: randomize list.

--- a/extra/zsh.completion
+++ b/extra/zsh.completion
@@ -6,7 +6,7 @@
 _arguments \
   '(-g --gallery)'{-g,--gallery}'[start in gallery mode]' \
   '(-r --recursive)'{-r,--recursive}'[read directories recursively]' \
-  '(-o --order)'{-o,--order=}'[set sort order for image list]:order:(none alpha mtime size random)' \
+  '(-o --order)'{-o,--order=}'[set sort order for image list]:order:(none alpha numeric mtime size random)' \
   '(-s --scale=SCALE)'{-s,--scale=}'[set initial image scale]:scale:(optimal width height fit fill real)' \
   '(-l --slideshow)'{-l,--slideshow}'[activate slideshow mode on startup]' \
   '(-f --fullscreen)'{-f,--fullscreen}'[show image in full screen mode]' \

--- a/src/imagelist.h
+++ b/src/imagelist.h
@@ -12,7 +12,8 @@
 /** Order of file list. */
 enum list_order {
     order_none,    ///< Unsorted (system depended)
-    order_alpha,   ///< Alphanumeric sort
+    order_alpha,   ///< Lexicographic sort
+    order_numeric, ///< Numeric sort
     order_mtime,   ///< Modification time sort
     order_size,    ///< Size sort
     order_random   ///< Random order

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@ struct cmdarg {
 static const struct cmdarg arguments[] = {
     { 'g', "gallery",    NULL,    "start in gallery mode" },
     { 'r', "recursive",  NULL,    "read directories recursively" },
-    { 'o', "order",      "ORDER", "set sort order for image list: none/alpha/mtime/size/random" },
+    { 'o', "order",      "ORDER", "set sort order for image list: none/alpha/numeric/mtime/size/random" },
     { 's', "scale",      "SCALE", "set initial image scale: [optimal]/fit/width/height/fill/real" },
     { 'l', "slideshow",  NULL,    "activate slideshow mode on startup" },
     { 'p', "position",   "POS",   "set window position [parent]/X,Y" },


### PR DESCRIPTION
The current `alpha` ordering sorts filenames with numbers out-of-order when they don't have leading zeroes. I've added a new order option that uses `strverscmp()` to produce a more natural numeric ordering.