### PR TITLE
Spelling, typos, and config consistency

### DIFF
--- a/extra/swayimg.1
+++ b/extra/swayimg.1
@@ -40,7 +40,7 @@ Read directories recursively.
 .IP "\fB\-o\fR, \fB\-\-order\fR=\fIORDER\fR:"
 Set order of the image list:
 .nf
-\fInone\fR: unsorted, order is system depended;
+\fInone\fR: unsorted, order is system-dependent;
 \fIalpha\fR: sorted alphabetically (default);
 \fInumeric\fR: sorted numerically;
 \fImtime\fR: sorted by file modification time;
@@ -64,7 +64,7 @@ Set the default image scale, valid modes are:
 Run slideshow mode on startup.
 .\" ----------------------------------------------------------------------------
 .IP "\fB\-f\fR, \fB\-\-fullscreen\fR"
-Start in full screen mode.
+Start in full-screen mode.
 .\" ----------------------------------------------------------------------------
 .IP "\fB\-p\fR, \fB\-\-position\fR=\fIPOS\fR"
 Set initial position of the window (Sway only):
@@ -83,12 +83,12 @@ Set initial size of the window:
 Set a constant window class/app_id.
 .\" ----------------------------------------------------------------------------
 .IP "\fB\-c\fR, \fB\-\-config\fR=\fISECTION.KEY=VALUE\fR"
-Set a configuration parameter, see swayimgrc(5) for a list of sections and its parameters.
+Set a configuration parameter, see swayimgrc(5) for a list of sections and their parameters.
 .\" ****************************************************************************
 .\" SWAY integration
 .\" ****************************************************************************
 .SH "SWAY MODE"
-The Sway compatible mode is automatically enabled if the environment variable
+The Sway compatibility mode is automatically enabled if the environment variable
 \fISWAYSOCK\fR points to a valid Sway IPC socket file.
 This mode provides some features such as setting the window position and getting
 the workspace layout.
@@ -152,7 +152,7 @@ swayimgrc(5)
 .\" Home page
 .\" ****************************************************************************
 .SH BUGS
-For suggestions, comments, bug reports etc. visit the
+For suggestions, comments, bug reports, etc. visit the
 .UR https://github.com/artemsen/swayimg
 project homepage
 .UE .

--- a/extra/swayimgrc
+++ b/extra/swayimgrc
@@ -39,11 +39,12 @@ app_id = swayimg
 window = #00000000
 # Background for transparent images (grid/RGBA)
 transparency = grid
-# Default image scale (optimal/fit/width/height/fill/real)
+# Default image scale (optimal/width/height/fit/fill/real)
 scale = optimal
 # Keep absolute zoom across images (yes/no)
 keep_zoom = no
 # Initial image position on the window
+# (top/center/bottom/left/right/topleft/topright/bottomleft/bottomright/free)
 position = center
 # Anti-aliasing mode (none/box/bilinear/bicubic/mks13)
 antialiasing = mks13
@@ -60,7 +61,7 @@ preload = 1
 # Gallery mode configuration
 ################################################################################
 [gallery]
-# Size of the thumbnail (pixels)
+# Height and width of each thumbnail (pixels)
 size = 200
 # Max number of thumbnails in memory cache, 0 for unlimited
 cache = 100
@@ -72,7 +73,7 @@ fill = yes
 antialiasing = mks13
 # Background color of the window (RGBA)
 window = #00000000
-# Background color of the tile (RGBA)
+# Background color of non-selected tiles (RGBA)
 background = #202020ff
 # Background color of the selected tile (RGBA)
 select = #404040ff
@@ -112,7 +113,7 @@ shadow = #000000d0
 background = #00000000
 
 ################################################################################
-# Image meta info scheme (format, size, EXIF, etc)
+# Image meta info scheme (format, size, EXIF, etc.)
 ################################################################################
 [info]
 # Show on startup (yes/no)
@@ -169,8 +170,8 @@ z = zoom fit
 Shift+z = zoom fill
 0 = zoom real
 BackSpace = zoom optimal
-Alt+s = scale
 Alt+z = keep_zoom
+Alt+s = scale
 bracketleft = rotate_left
 bracketright = rotate_right
 m = flip_vertical

--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -43,19 +43,19 @@ line, for instance: `swayimg --config="general.mode=gallery"`.
 .\" ****************************************************************************
 .SH "SECTIONS"
 .SS "General"
-The general configuration is stored in the section \fB[general]\fR.
+General configuration (for the whole application) is in section \fB[general]\fR.
 .\" ----------------------------------------------------------------------------
 .IP "\fBmode\fR = \fI[viewer|gallery]\fR"
 Mode used at startup, \fIviewer\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBposition\fR = \fI[parent|X,Y]\fR"
-Set initial position of the window (Sway only):
+Initial window position (Sway only):
 .nf
 \fIparent\fR: set position from parent (currently active) window (default);
 \fIX,Y\fR: absolute coordinates of the top left corner, e.g. 100,200.
 .\" ----------------------------------------------------------------------------
 .IP "\fBsize\fR = \fI[fullscreen|parent|image|W,H]\fR"
-Set initial size of the window:
+Initial window size:
 .nf
 \fIfullscreen\fR: use fullscreen mode;
 \fIparent\fR: set size from parent (currently active) window (Sway only, default);
@@ -66,22 +66,20 @@ Set initial size of the window:
 Use window decoration (borders and title), \fIno\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBsigusr1\fR = \fIACTION\fR"
-Set the action to be performed when the SIGUSR1 signal is triggered.
-Default value is \fIreload\fR.
+Action to be performed when the SIGUSR1 signal is triggered, \fIreload\fR by default.
 .IP "\fBsigusr2\fR = \fIACTION\fR"
-Set the action to be performed when the SIGUSR2 signal is triggered.
-Default value is \fInext_file\fR.
+Action to be performed when the SIGUSR2 signal is triggered, \fInext_file\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBapp_id\fR = \fINAME\fR"
-Application ID used as window class name.
+Application ID used as window class name, \fIswayimg\fR by default.
 .\" ****************************************************************************
 .\" Viewer config section
 .\" ****************************************************************************
 .SS "Viewer"
-Configuration is defined in the \fB[viewer]\fR section.
+Configuration specific to the viewer mode is in section \fB[viewer]\fR.
 .\" ----------------------------------------------------------------------------
 .IP "\fBwindow\fR = \fI#COLOR\fR"
-Window background color in RGB or RGBA format, default is \fI#00000000\fR.
+Window background color in RGB or RGBA format, \fI#00000000\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBtransparency\fR = \fI[grid|#COLOR]\fR"
 Background for transparent images:
@@ -103,7 +101,7 @@ Default image scale, valid modes are:
 Keep absolute zoom across images, \fIno\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBposition\fR = \fIPOSITION\fR"
-# Initial image position on the window, valid modes are:
+Initial image position on the window, valid modes are:
 .nf
 \fItop\fR: move image to top and center by width;
 \fIcenter\fR: center by width and height (default);
@@ -117,13 +115,13 @@ Keep absolute zoom across images, \fIno\fR by default.
 \fIfree\fR: like center, but freely movable (not fixed).
 .\" ----------------------------------------------------------------------------
 .IP "\fBantialiasing\fR = \fIMETHOD\fR"
-Scale method to use when anti-aliasing is enabled, valid choices are:
+Anti-aliasing method when scaling images, valid options are:
 .nf
-\fInearest\fR: nearest-neighbor, equivalent to antialiasing = no;
+\fInone\fR: nearest-neighbor, or no anti-aliasing;
 \fIbox\fR: nearest-neighbor on upscale, average in a box on downscale;
 \fIbilinear\fR: bilinear;
 \fIbicubic\fR: bicubic with the Catmull-Rom spline;
-\fImks13\fR: Magic Kernel with the 2013 Sharp approximation (default);
+\fImks13\fR: Magic Kernel with the 2013 Sharp approximation (default).
 .nf
 In general, the methods improve in quality and decrease in performance from top to bottom.
 .\" ----------------------------------------------------------------------------
@@ -131,7 +129,7 @@ In general, the methods improve in quality and decrease in performance from top 
 Run slideshow at startup, \fIno\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBslideshow_time\fR = \fISECONDS\fR"
-Set slideshow image duration in seconds, default is \fI3\fR.
+Slideshow image duration in seconds, \fI3\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBhistory\fR = \fISIZE\fR"
 Number of previously viewed images to store in cache, \fI1\fR by default.
@@ -142,10 +140,13 @@ Number of images to preload in a separate thread, \fI1\fR by default.
 .\" Gallery config section
 .\" ****************************************************************************
 .SS "Gallery"
-Configuration is defined in the \fB[gallery]\fR section.
+Configuration specific to the gallery mode is in section \fB[gallery]\fR.
 .\" ----------------------------------------------------------------------------
 .IP "\fBsize\fR = \fIPIXELS\fR"
-Size of the thumbnail in pixels, \fI200\fR by default.
+Height and width of each thumbnail in pixels, \fI200\fR by default.
+.\" ----------------------------------------------------------------------------
+.IP "\fBcache\fR = \fISIZE\fR"
+Max number of thumbnails in cache, \fI0\fR for unlimited, \fI100\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBpstore\fR = \fI[yes|no]\fR"
 Enable/disable storing thumbnails in persistent storage, \fIno\fR by default.
@@ -153,41 +154,41 @@ Enable/disable storing thumbnails in persistent storage, \fIno\fR by default.
 .IP "\fBfill\fR = \fI[yes|no]\fR"
 Fill the entire tile with thumbnail, \fIyes\fR by default.
 .\" ----------------------------------------------------------------------------
-.IP "\fBcache\fR = \fISIZE\fR"
-Max number of thumbnails in cache, \fI0\fR for unlimited, \fI100\fR by default.
-.\" ----------------------------------------------------------------------------
 .IP "\fBantialiasing\fR = \fIMETHOD\fR"
-Scale method to use when anti-aliasing is enabled, valid choices are:
+Anti-aliasing method when scaling thumbnails, valid options are:
 .nf
-\fInearest\fR: nearest-neighbor, equivalent to antialiasing = no;
+\fInone\fR: nearest-neighbor, or no anti-aliasing;
 \fIbox\fR: nearest-neighbor on upscale, average in a box on downscale;
 \fIbilinear\fR: bilinear;
 \fIbicubic\fR: bicubic with the Catmull-Rom spline;
-\fImks13\fR: Magic Kernel with the 2013 Sharp approximation (default);
+\fImks13\fR: Magic Kernel with the 2013 Sharp approximation (default).
 .nf
 In general, the methods improve in quality and decrease in performance from top to bottom.
 .\" ----------------------------------------------------------------------------
 .IP "\fBwindow\fR = \fI#COLOR\fR"
-Background color of the window, default is \fI#00000000\fR.
+Background color of the window, \fI#00000000\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBbackground\fR = \fI#COLOR\fR"
-Background color of the tile, default is \fI#202020ff\fR.
+Background color of non-selected tiles, \fI#202020ff\fR by default.
+.\" ----------------------------------------------------------------------------
+.IP "\fBselect\fR = \fI#COLOR\fR"
+Background color of the selected tile, \fI#404040ff\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBborder\fR = \fI#COLOR\fR"
-Border color of the selected tile, default is \fI#000000ff\fR.
+Border color of the selected tile, \fI#000000ff\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBshadow\fR = \fI#COLOR\fR"
-Shadow color of the selected tile, default is \fI#000000ff\fR.
+Shadow color of the selected tile, \fI#000000ff\fR by default.
 .\" ****************************************************************************
 .\" Image list config section
 .\" ****************************************************************************
 .SS "Image list"
-The image list configuration is stored in the section \fB[list]\fR.
+Configuration of the image list is in section \fB[list]\fR.
 .\" ----------------------------------------------------------------------------
 .IP "\fBorder\fR = \fIORDER\fR"
-Set order of the image list:
+Order of the image list:
 .nf
-\fInone\fR: unsorted, order is system depended;
+\fInone\fR: unsorted, order is system-dependent;
 \fIalpha\fR: sorted alphabetically (default);
 \fInumeric\fR: sorted numerically;
 \fImtime\fR: sorted by file modification time;
@@ -195,7 +196,7 @@ Set order of the image list:
 \fIrandom\fR: randomize list.
 .\" ----------------------------------------------------------------------------
 .IP "\fBreverse\fR\fR = \fI[yes|no]\fR"
-Reverse sort order, \fIno\fR by default. 
+Reverse sort order, \fIno\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBloop\fR\fR = \fI[yes|no]\fR"
 Looping file list mode, \fIyes\fR by default.
@@ -209,63 +210,64 @@ Open all files in the directory of the specified file, \fIno\fR by default.
 .\" Font config section
 .\" ****************************************************************************
 .SS "Font"
-The font configuration is stored in the section \fB[font]\fR.
+Font configuration is in section \fB[font]\fR.
 .\" ----------------------------------------------------------------------------
 .IP "\fBname\fR\fR = \fINAME\fR"
-Set the font name used for text, default is \fImonospace\fR.
+Font name, \fImonospace\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBsize\fR = \fISIZE\fR"
-Set the font size (in pt), default is \fI14\fR.
+Font size (in pt), \fI14\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBcolor\fR = \fI#COLOR\fR"
-Set text color in RGBA format, default is \fI#ccccccff\fR.
-.\" ----------------------------------------------------------------------------
-.IP "\fBbackground\fR = \fI#COLOR\fR"
-Text background color, default is \fI#00000000\fR (none).
+Text color, \fI#ccccccff\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBshadow\fR = \fI#COLOR\fR"
-Draw text shadow with specified color, default is \fI#000000d0\fR.
+Text shadow color, \fI#000000d0\fR by default.
+.nf
 To disable shadow use fully transparent color \fI#00000000\fR.
+.\" ----------------------------------------------------------------------------
+.IP "\fBbackground\fR = \fI#COLOR\fR"
+Text background color, \fI#00000000\fR (none) by default.
 .\" ****************************************************************************
 .\" Text info config section
 .\" ****************************************************************************
 .SS "Text info: common configuration"
-The section \fB[info]\fR describes how to display image meta data (file name,
-size, EXIF etc).
+Section \fB[info]\fR describes how to display image metadata (file name,
+size, EXIF, etc.) in general.
 .\" ----------------------------------------------------------------------------
 .IP "\fBshow\fR = \fI[yes|no]\fR"
 Enable or disable info text at startup, \fIyes\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBinfo_timeout\fR = \fISECONDS\fR"
-Timeout of image information displayed on the screen, 0 to always show, default is \fI5\fR.
+Timeout of image information displayed on the screen, 0 to always show, \fI5\fR by default.
 .\" ----------------------------------------------------------------------------
 .IP "\fBstatus_timeout\fR = \fISECONDS\fR"
-Timeout of the status message displayed on the screen, default is \fI3\fR.
+Timeout of the status message displayed on the screen, \fI3\fR by default.
 .\" ----------------------------------------------------------------------------
 .SS "Text info: viewer"
-The section \fB[info.viewer]\fR describes how to display image meta data (file
-name, size, EXIF etc) in viewer mode.
-Each key/value configures a set of fields and their format.
+Section \fB[info.viewer]\fR describes what image metadata to display in viewer mode.
+.nf
+Metadata may be displayed in any corner of the screen. This section defines
+the following keys, each of which describes the metadata to appear in that location:
 .IP "\fBtop_left\fR = \fILIST\fR"
-Set the display scheme for the upper left corner of the window.
+Default is \fI+name,+format,+filesize,+imagesize,+exif\fR.
 .IP "\fBtop_right\fR = \fILIST\fR"
-Set the display scheme for the upper right corner of the window.
+Default is \fIindex\fR.
 .IP "\fBbottom_left\fR = \fILIST\fR"
-Set the display scheme for the lower left corner of the window.
+Default is \fIscale,frame\fR.
 .IP "\fBbottom_right\fR = \fILIST\fR"
-Set the display scheme for the lower right corner of the window.
+Default is \fIstatus\fR.
 .PP
-\fILIST\fR can contain any number of fields separated by commas.
-Plus at the beginning of a field name adds the field title to the display.
-Available fields:
+\fILIST\fR may contain any number of the following fields, separated by commas.
+A plus sign preceding a field name adds the field title to the display.
 .IP "\fIname\fR"
 File name of the currently viewed/selected image.
 .IP "\fIdir\fR"
-Parent directory name the currently viewed/selected image.
+Parent directory name of the currently viewed/selected image.
 .IP "\fIpath\fR"
 Absolute path or special source string of the currently viewed/selected image.
 .IP "\fIfilesize\fR"
-File size in human readable format.
+File size in human-readable format.
 .IP "\fIformat\fR"
 Brief image format description.
 .IP "\fIimagesize\fR"
@@ -284,8 +286,17 @@ Status message.
 Empty field (ignored).
 .\" ----------------------------------------------------------------------------
 .SS "Text info: gallery"
-The section \fB[info.gallery]\fR describes how to display image meta data (file
-name, size, EXIF etc) in gallery mode, same format as for viewer mode.
+Section \fB[info.gallery]\fR describes what image metadata to display in gallery mode.
+.nf
+It follows the same format as \fB[info.viewer]\fR, with the following keys:
+.IP "\fBtop_left\fR = \fILIST\fR"
+Default is \fInone\fR.
+.IP "\fBtop_right\fR = \fILIST\fR"
+Default is \fInone\fR.
+.IP "\fBbottom_left\fR = \fILIST\fR"
+Default is \fInone\fR.
+.IP "\fBbottom_right\fR = \fILIST\fR"
+Default is \fIname,status\fR.
 .\" ****************************************************************************
 .\" Key bindings config section
 .\" ****************************************************************************
@@ -307,7 +318,7 @@ Predefined names for mouse scroll:
 .PP
 .\" ----------------------------------------------------------------------------
 .SS "Viewer mode actions"
-.IP "\fBnone\fR: can be used for removing built-in action;"
+.IP "\fBnone\fR: can be used to remove a built-in action;"
 .IP "\fBhelp\fR: show/hide help;"
 .IP "\fBfirst_file\fR: jump to the first file;"
 .IP "\fBlast_file\fR: jump to the last file;"
@@ -321,7 +332,7 @@ Predefined names for mouse scroll:
 .IP "\fBskip_file\fR: skip the current file (remove from the image list);"
 .IP "\fBanimation\fR: start/stop animation;"
 .IP "\fBslideshow\fR: start/stop slideshow;"
-.IP "\fBfullscreen\fR: switch full screen mode;"
+.IP "\fBfullscreen\fR: toggle full-screen mode;"
 .IP "\fBmode \fI[MODE]\fR\fR: switch between viewer and gallery;"
 .IP "\fBstep_left\fR \fI[PERCENT]\fR: move viewport left, default is 10%;"
 .IP "\fBstep_right\fR \fI[PERCENT]\fR: move viewport right, default is 10%;"
@@ -335,15 +346,15 @@ Predefined names for mouse scroll:
 .IP "\fBflip_vertical\fR: flip image vertically;"
 .IP "\fBflip_horizontal\fR: flip image horizontally;"
 .IP "\fBreload\fR: reset cache and reload current image;"
-.IP "\fBantialiasing\fR \fI[MODE]\fR: switch antialiasing mode or set specified one (\fInext\fR/\fIprev\fR or mode name);"
-.IP "\fBinfo\fR \fI[MODE]\fR: switch text info mode or set specified one (\fIoff\fR/\fIviewer\fR/\fIgallery\fR);"
+.IP "\fBantialiasing\fR \fI[MODE]\fR: set anti-aliasing mode or cycle through them (\fInext\fR/\fIprev\fR or mode name);"
+.IP "\fBinfo\fR \fI[MODE]\fR: set info mode or cycle through them (\fIoff\fR/\fIviewer\fR/\fIgallery\fR);"
 .IP "\fBexec\fR \fICOMMAND\fR: execute an external command, use % to substitute the path to the current image, %% to escape %;"
 .IP "\fBexport\fR \fIFILE\fR: export currently displayed image to PNG file;"
 .IP "\fBstatus\fR \fITEXT\fR: print message in the status field;"
 .IP "\fBexit\fR: exit the application."
 .\" ----------------------------------------------------------------------------
 .SS "Gallery mode actions"
-.IP "\fBnone\fR: can be used for removing built-in action;"
+.IP "\fBnone\fR: can be used to remove a built-in action;"
 .IP "\fBhelp\fR: show/hide help;"
 .IP "\fBfirst_file\fR: jump to the first file;"
 .IP "\fBlast_file\fR: jump to the last file;"
@@ -356,11 +367,11 @@ Predefined names for mouse scroll:
 .IP "\fBpage_up\fR: scroll page up;"
 .IP "\fBpage_down\fR: scroll page down;"
 .IP "\fBskip_file\fR: skip the current file (remove from the image list);"
-.IP "\fBfullscreen\fR: switch full screen mode;"
+.IP "\fBfullscreen\fR: toggle full-screen mode;"
 .IP "\fBmode\fR: switch between viewer and gallery;"
 .IP "\fBreload\fR: reset cache and reload current image;"
-.IP "\fBantialiasing\fR \fI[MODE]\fR: switch antialiasing mode or set specified one (\fInext\fR/\fIprev\fR or mode name);"
-.IP "\fBinfo\fR \fI[MODE]\fR: switch text info mode or set specified one (\fIoff\fR/\fIviewer\fR/\fIgallery\fR);"
+.IP "\fBantialiasing\fR \fI[MODE]\fR: set anti-aliasing mode or cycle through them (\fInext\fR/\fIprev\fR or mode name);"
+.IP "\fBinfo\fR \fI[MODE]\fR: set info mode or cycle through them (\fIoff\fR/\fIviewer\fR/\fIgallery\fR);"
 .IP "\fBexec\fR \fICOMMAND\fR: execute an external command, use % to substitute the path to the current image, %% to escape %;"
 .IP "\fBstatus\fR \fITEXT\fR: print message in the status field;"
 .IP "\fBexit\fR: exit the application."
@@ -388,7 +399,7 @@ swayimg(1)
 .\" Home page
 .\" ****************************************************************************
 .SH BUGS
-For suggestions, comments, bug reports etc. visit the
+For suggestions, comments, bug reports, etc. visit the
 .UR https://github.com/artemsen/swayimg
 project homepage
 .UE .

--- a/src/config.c
+++ b/src/config.c
@@ -86,9 +86,9 @@ static const struct config_default defaults[] = {
     { CFG_KEYS_VIEWER,  "Prior",            "prev_file"              },
     { CFG_KEYS_VIEWER,  "Next",             "next_file"              },
     { CFG_KEYS_VIEWER,  "Space",            "next_file"              },
+    { CFG_KEYS_VIEWER,  "Shift+r",          "rand_file"              },
     { CFG_KEYS_VIEWER,  "Shift+d",          "prev_dir"               },
     { CFG_KEYS_VIEWER,  "d",                "next_dir"               },
-    { CFG_KEYS_VIEWER,  "Shift+r",          "rand_file"              },
     { CFG_KEYS_VIEWER,  "Shift+o",          "prev_frame"             },
     { CFG_KEYS_VIEWER,  "o",                "next_frame"             },
     { CFG_KEYS_VIEWER,  "c",                "skip_file"              },
@@ -110,6 +110,7 @@ static const struct config_default defaults[] = {
     { CFG_KEYS_VIEWER,  "0",                "zoom real"              },
     { CFG_KEYS_VIEWER,  "BackSpace",        "zoom optimal"           },
     { CFG_KEYS_VIEWER,  "Alt+z",            "keep_zoom"              },
+    { CFG_KEYS_VIEWER,  "Alt+s",            "scale"                  },
     { CFG_KEYS_VIEWER,  "bracketleft",      "rotate_left"            },
     { CFG_KEYS_VIEWER,  "bracketright",     "rotate_right"           },
     { CFG_KEYS_VIEWER,  "m",                "flip_vertical"          },
@@ -419,7 +420,7 @@ bool config_set(struct config* cfg, const char* section, const char* key,
     if (!value || !*value) {
         fprintf(stderr,
                 "WARNING: Empty config value for key \"%s\" in section \"%s\" "
-                "is not alowed\n",
+                "is not allowed\n",
                 key, section);
         return false;
     }

--- a/src/formats/qoi.c
+++ b/src/formats/qoi.c
@@ -15,7 +15,7 @@
 #define QOI_OP_RGB   0xfe
 #define QOI_OP_RGBA  0xff
 
-// Mask of second byte in steram
+// Mask of second byte in stream
 #define QOI_MASK_2 0xc0
 
 // Size of color map

--- a/src/gallery.c
+++ b/src/gallery.c
@@ -38,9 +38,9 @@ struct gallery {
     size_t curr_col;       ///< Selected image column
     size_t curr_row;       ///< Selected image row
 
-    size_t layout_columns; ///< Number of thumnail columns
-    size_t layout_rows;    ///< Number of thumnail rows
-    size_t layout_padding; ///< Space between thumnails
+    size_t layout_columns; ///< Number of thumbnail columns
+    size_t layout_rows;    ///< Number of thumbnail rows
+    size_t layout_padding; ///< Space between thumbnails
 
     pthread_t loader_tid; ///< Thumbnail loader thread id
     bool loader_active;   ///< Preload in progress flag
@@ -430,7 +430,7 @@ static bool select_next(enum action_type direction)
     }
 
     if (next) {
-        // set position od selected image
+        // set position of selected image
         if (next_col < 0) {
             next_col = ctx.layout_columns - 1;
             --next_row;

--- a/src/pixmap.h
+++ b/src/pixmap.h
@@ -47,7 +47,7 @@ struct pixmap {
 };
 
 /**
- * Allocate/reallocate pixel map.
+ * Allocate/reallocate pixmap.
  * @param pm pixmap context to create
  * @param width,height pixmap size
  * @return true pixmap was allocated
@@ -55,7 +55,7 @@ struct pixmap {
 bool pixmap_create(struct pixmap* pm, size_t width, size_t height);
 
 /**
- * Free pixel map created with `pixmap_create`.
+ * Free pixmap created with `pixmap_create`.
  * @param pm pixmap context to free
  */
 void pixmap_free(struct pixmap* pm);
@@ -85,7 +85,7 @@ void pixmap_inverse_fill(struct pixmap* pm, ssize_t x, ssize_t y, size_t width,
  * @param pm pixmap context
  * @param x,y start coordinates, left top point
  * @param width,height region size
- * @param color color to set
+ * @param color color to blend
  */
 void pixmap_blend(struct pixmap* pm, ssize_t x, ssize_t y, size_t width,
                   size_t height, argb_t color);
@@ -149,25 +149,25 @@ void pixmap_apply_mask(struct pixmap* pm, ssize_t x, ssize_t y,
  * @param src source pixmap
  * @param dst destination pixmap
  * @param x,y destination left top coordinates
- * @param alpha flag to use alpha blending
+ * @param alpha flag to use alpha channel (ignore otherwise)
  */
 void pixmap_copy(const struct pixmap* src, struct pixmap* dst, ssize_t x,
                  ssize_t y, bool alpha);
 
 /**
- * Flip pixel map vertically.
+ * Flip pixmap vertically.
  * @param pm pixmap context
  */
 void pixmap_flip_vertical(struct pixmap* pm);
 
 /**
- * Flip pixel map horizontally.
+ * Flip pixmap horizontally.
  * @param pm pixmap context
  */
 void pixmap_flip_horizontal(struct pixmap* pm);
 
 /**
- * Rotate pixel map.
+ * Rotate pixmap.
  * @param pm pixmap context
  * @param angle rotation angle (only 90, 180, or 270)
  */

--- a/src/pixmap_scale.h
+++ b/src/pixmap_scale.h
@@ -27,7 +27,7 @@ enum aa_mode aa_init(const struct config* cfg, const char* section,
 /**
  * Switch anti-aliasing mode.
  * @param curr current anti-aliasing mode
- * @param opt switch opration
+ * @param opt switch operation
  * @return new anti-aliasing mode or current if opt has invalid format
  */
 enum aa_mode aa_switch(enum aa_mode curr, const char* opt);
@@ -46,7 +46,7 @@ const char* aa_name(enum aa_mode aa);
  * @param dst destination pixmap
  * @param x,y destination left top coordinates
  * @param scale scale of source pixmap
- * @param alpha flag to use alpha blending
+ * @param alpha flag to use alpha channel (ignore otherwise)
  */
 void pixmap_scale(enum aa_mode scaler, const struct pixmap* src,
                   struct pixmap* dst, ssize_t x, ssize_t y, float scale,

--- a/src/shellcmd.c
+++ b/src/shellcmd.c
@@ -18,7 +18,7 @@
  * @param fd stdout file descriptor
  * @param out pointer to stdout buffer, caller should free the buffer
  * @param sz size of output buffer
- * @return 0 on sucess or error code
+ * @return 0 on success or error code
  */
 static int read_stdout(int fd, uint8_t** out, size_t* sz)
 {
@@ -66,7 +66,7 @@ static int read_stdout(int fd, uint8_t** out, size_t* sz)
  * @param cmd command to execute
  * @param in_fd stdin file descriptor
  * @param out_fd stdout file descriptor
- * @return 0 on sucess or error code
+ * @return 0 on success or error code
  */
 static int execute(const char* cmd, int in_fd, int out_fd)
 {

--- a/src/shellcmd.h
+++ b/src/shellcmd.h
@@ -12,7 +12,7 @@
  * @param cmd command to execute
  * @param out pointer to stdout buffer, caller should free the buffer
  * @param sz size of output buffer
- * @return suprocess exit code
+ * @return subprocess exit code
  */
 int shellcmd_exec(const char* cmd, uint8_t** out, size_t* sz);
 
@@ -21,6 +21,6 @@ int shellcmd_exec(const char* cmd, uint8_t** out, size_t* sz);
  * @param expr command expression
  * @param path file path to substitute into expression
  * @param out pointer to stdout buffer, caller should free the buffer
- * @return suprocess exit code
+ * @return subprocess exit code
  */
 int shellcmd_expr(const char* expr, const char* path, char** out);

--- a/src/sway.h
+++ b/src/sway.h
@@ -34,7 +34,7 @@ void sway_disconnect(int ipc);
  * Get geometry for currently focused window.
  * @param ipc IPC context
  * @param wnd geometry of currently focused window
- * @param border size og window border in pixels
+ * @param border size of window border in pixels
  * @param fullscreen current full screen mode
  * @return true if operation completed successfully
  */

--- a/src/ui.c
+++ b/src/ui.c
@@ -528,7 +528,7 @@ static void on_registry_global(void* data, struct wl_registry* registry,
         xdg_wm_base_add_listener(ctx.xdg.base, &xdg_base_listener, data);
 
     } else if (strcmp(interface, wl_seat_interface.name) == 0) {
-        // seat (keayboard and mouse)
+        // seat (keyboard and mouse)
         ctx.wl.seat = wl_registry_bind(registry, name, &wl_seat_interface,
                                        WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION);
         wl_seat_add_listener(ctx.wl.seat, &seat_listener, data);

--- a/src/wndbuf.h
+++ b/src/wndbuf.h
@@ -17,9 +17,9 @@
 struct wl_buffer* wndbuf_create(struct wl_shm* shm, size_t width,
                                 size_t height);
 /**
- * Get pixel map assiciated with the buffer.
+ * Get pixmap associated with the buffer.
  * @param buffer wayland buffer
- * @return pointer to pixel map assiciated with the buffer
+ * @return pointer to pixmap associated with the buffer
  */
 struct pixmap* wndbuf_pixmap(struct wl_buffer* buffer);
 


### PR DESCRIPTION
Fixed some small typos and spelling errors, but mostly ensured swayimgrc, swayimgrc(5), and config.c matched (there were a couple of cases where they didn't entirely).