### PR TITLE
Fix heap overflow

### DIFF
--- a/src/pixmap_scale.c
+++ b/src/pixmap_scale.c
@@ -646,12 +646,13 @@ void pixmap_scale(enum aa_mode scaler, const struct pixmap* src,
                   bool alpha)
 {
     // get size of rendered area
-    const size_t width =
-        min((ssize_t)dst->width, x + scale * src->width) - max(0, x);
-    const size_t height =
-        min((ssize_t)dst->height, y + scale * src->height) - max(0, y);
+    const ssize_t width =
+        min((ssize_t)dst->width, (ssize_t)(x + scale * src->width)) - max(0, x);
+    const ssize_t height =
+        min((ssize_t)dst->height, (ssize_t)(y + scale * src->height)) -
+        max(0, y);
 
-    if (width == 0 || height == 0) {
+    if (width <= 0 || height <= 0) {
         return; // out of destination
     }
 

--- a/test/pixmap_test.cpp
+++ b/test/pixmap_test.cpp
@@ -639,20 +639,34 @@ TEST_F(Pixmap, ScaleCopyDownPos)
     ScaleCopy(aa_bilinear, pm, 2, 2, 0.5, 1, 1);
 }
 
-/*
-TODO: This test crashes: https://github.com/artemsen/swayimg/issues/277
-
-TEST_F(Pixmap, ScaleCrash)
+TEST_F(Pixmap, ScaleOutside)
 {
+    // Scale outside the destination in each direction
     struct pixmap src;
     pixmap_create(&src, 2000, 2000);
+    pixmap_fill(&src, 0, 0, 2000, 2000, ARGB(0xff, 0xff, 0, 0));
 
     struct pixmap dst;
     pixmap_create(&dst, 1000, 700);
+    pixmap_fill(&dst, 0, 0, 1000, 700, ARGB(0xff, 0, 0xff, 0));
+
+    struct pixmap expect;
+    pixmap_create(&expect, 1000, 700);
+    pixmap_copy(&dst, &expect, 0, 0, false);
 
     pixmap_scale(aa_mks13, &src, &dst, 0, -670, 0.3, false);
+    Compare(dst, expect.data);
+
+    pixmap_scale(aa_mks13, &src, &dst, 0, 700, 0.3, false);
+    Compare(dst, expect.data);
+
+    pixmap_scale(aa_mks13, &src, &dst, -670, 0, 0.3, false);
+    Compare(dst, expect.data);
+
+    pixmap_scale(aa_mks13, &src, &dst, 1000, 0, 0.3, false);
+    Compare(dst, expect.data);
 
     pixmap_free(&src);
     pixmap_free(&dst);
+    pixmap_free(&expect);
 }
-*/


### PR DESCRIPTION
At least locally, this addressed the overflow for me.

The second commit makes the test much longer, so you're welcome to omit it if you're concerned about CI pipeline duration, for example.