### PR TITLE
feat: rerender SVGs at current scale

### DIFF
--- a/extra/swayimgrc
+++ b/extra/swayimgrc
@@ -183,6 +183,7 @@ Shift+m = flip_horizontal
 a = antialiasing next
 Shift+a = antialiasing prev
 r = reload
+Alt+r = svg_rerender
 i = info
 Shift+Delete = exec rm -f '%' && echo "File removed: %"; skip_file
 Escape = exit

--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -354,6 +354,7 @@ Predefined names for mouse scroll:
 .IP "\fBrotate_right\fR: rotate image clockwise;"
 .IP "\fBflip_vertical\fR: flip image vertically;"
 .IP "\fBflip_horizontal\fR: flip image horizontally;"
+.IP "\fBsvg_rerender\fR: rerender SVG with current zoom level;"
 .IP "\fBreload\fR: reset cache and reload current image;"
 .IP "\fBantialiasing\fR \fI[MODE]\fR: set anti-aliasing mode or cycle through them (\fInext\fR/\fIprev\fR or mode name);"
 .IP "\fBinfo\fR \fI[MODE]\fR: set info mode or cycle through them (\fIoff\fR/\fIviewer\fR/\fIgallery\fR);"

--- a/src/action.c
+++ b/src/action.c
@@ -46,6 +46,7 @@ static const char* action_names[] = {
     [action_flip_horizontal] = "flip_horizontal",
     [action_reload] = "reload",
     [action_antialiasing] = "antialiasing",
+    [action_svg_rerender] = "svg_rerender",
     [action_info] = "info",
     [action_exec] = "exec",
     [action_export] = "export",

--- a/src/action.h
+++ b/src/action.h
@@ -40,6 +40,7 @@ enum action_type {
     action_flip_horizontal,
     action_reload,
     action_antialiasing,
+    action_svg_rerender,
     action_info,
     action_exec,
     action_export,

--- a/src/config.c
+++ b/src/config.c
@@ -123,6 +123,7 @@ static const struct config_default defaults[] = {
     { CFG_KEYS_VIEWER,  "a",                "antialiasing next"      },
     { CFG_KEYS_VIEWER,  "Shift+a",          "antialiasing prev"      },
     { CFG_KEYS_VIEWER,  "r",                "reload"                 },
+    { CFG_KEYS_VIEWER,  "Alt+r",            "svg_rerender"           },
     { CFG_KEYS_VIEWER,  "i",                "info"                   },
     { CFG_KEYS_VIEWER,  "Shift+Delete",     RM_FILE_ACTION           },
     { CFG_KEYS_VIEWER,  "Escape",           "exit"                   },

--- a/src/formats/loader.c
+++ b/src/formats/loader.c
@@ -182,6 +182,17 @@ static enum image_status load_from_memory(struct image* img,
         status = decoders[i](img, data, size);
     }
 
+    if (status == imgload_success) {
+        uint8_t* dest = malloc(size);
+        if (dest) {
+            memcpy(dest, data, size);
+            img->file_raw = dest;
+        } else {
+            status = imgload_ioerror;
+            img->file_raw = NULL;
+        }
+    }
+
     img->file_size = size;
 
     return status;

--- a/src/formats/svg.c
+++ b/src/formats/svg.c
@@ -34,7 +34,7 @@ void adjust_svg_render_size(double scale)
     }
 }
 
-void reset_svg_render_size()
+void reset_svg_render_size(void)
 {
     current_render_size = RENDER_SIZE_BASE;
 }

--- a/src/formats/svg.h
+++ b/src/formats/svg.h
@@ -16,4 +16,4 @@ void adjust_svg_render_size(double scale);
 /**
  * Reset the render size to RENDER_SIZE_BASE
  */
-void reset_svg_render_size();
+void reset_svg_render_size(void);

--- a/src/formats/svg.h
+++ b/src/formats/svg.h
@@ -17,3 +17,14 @@ void adjust_svg_render_size(double scale);
  * Reset the render size to RENDER_SIZE_BASE
  */
 void reset_svg_render_size(void);
+
+/**
+ * Decode an SVG with a partial viewport.
+ * @param img the source image
+ * @param dst destination pixmap
+ * @param x,y destination left top coordinates
+ * @param scale scale of source pixmap
+ */
+enum image_status decode_svg_partial(struct image* img,
+                                     const struct pixmap* dst, ssize_t x,
+                                     ssize_t y, double scale);

--- a/src/formats/svg.h
+++ b/src/formats/svg.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// SVG format decoder.
+
+#pragma once
+
+// SVG decoder implementation
+enum image_status decode_svg(struct image* img, const uint8_t* data,
+                             size_t size);
+
+/**
+ * Adjust the render size of SVG images
+ * @param scale target scale factor (* RENDER_SIZE_BASE)
+ */
+void adjust_svg_render_size(double scale);
+
+/**
+ * Reset the render size to RENDER_SIZE_BASE
+ */
+void reset_svg_render_size();

--- a/src/image.c
+++ b/src/image.c
@@ -96,6 +96,10 @@ void image_free(struct image* img, size_t dt)
             free(it);
         }
         img->info = NULL;
+
+        // free raw image data
+        free(img->file_raw);
+        img->file_raw = NULL;
     }
 
     if (dt == IMGFREE_ALL) {

--- a/src/image.h
+++ b/src/image.h
@@ -32,9 +32,10 @@ struct image_info {
 struct image {
     struct list list; ///< Links to prev/next entry in the image list
 
-    char* source;     ///< Image source (e.g. path to the image file)
-    size_t file_size; ///< Size of the image file
-    time_t file_time; ///< File modification time
+    char* source;      ///< Image source (e.g. path to the image file)
+    uint8_t* file_raw; ///< Raw image file data
+    size_t file_size;  ///< Size of the image file
+    time_t file_time;  ///< File modification time
 
     size_t index;     ///< Index of the image
     const char* name; ///< Name of the image file

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -838,6 +838,17 @@ static void draw_image(struct pixmap* wnd)
     if (ctx.scale == 1.0) {
         pixmap_copy(pm, wnd, ctx.img_x, ctx.img_y, ctx.current->alpha);
     } else {
+#ifdef HAVE_LIBRSVG
+        if (strcmp(ctx.current->format, "SVG") == 0) {
+
+            enum image_status status = decode_svg_partial(
+                ctx.current, wnd, ctx.img_x, ctx.img_y, ctx.scale);
+
+            if (status == imgload_success) {
+                return;
+            }
+        }
+#endif
         pixmap_scale(ctx.aa_mode, pm, wnd, ctx.img_x, ctx.img_y, ctx.scale,
                      ctx.current->alpha);
     }

--- a/test/image_test.cpp
+++ b/test/image_test.cpp
@@ -113,21 +113,21 @@ TEST_F(Image, LoadFromExec)
 #ifdef HAVE_LIBRSVG
 TEST_F(Image, RescaleSVG)
 {
-    Load(TEST_DATA_DIR "/image.svg");
+    image = image_create(TEST_DATA_DIR "/image.svg");
+    ASSERT_TRUE(image);
+    ASSERT_EQ(image_load(image), imgload_success);
     ASSERT_TRUE(image->frames[0].pm.height == 1024);
     ASSERT_TRUE(image->frames[0].pm.width == 1024);
 
     adjust_svg_render_size(1.5);
 
-    image_free(image, IMGFREE_FRAMES);
-    Load(TEST_DATA_DIR "/image.svg");
+    ASSERT_EQ(image_load(image), imgload_success);
     ASSERT_TRUE(image->frames[0].pm.height == 1536);
     ASSERT_TRUE(image->frames[0].pm.width == 1536);
 
     reset_svg_render_size();
 
-    image_free(image, IMGFREE_FRAMES);
-    Load(TEST_DATA_DIR "/image.svg");
+    ASSERT_EQ(image_load(image), imgload_success);
     ASSERT_TRUE(image->frames[0].pm.height == 1024);
     ASSERT_TRUE(image->frames[0].pm.width == 1024);
 }

--- a/test/image_test.cpp
+++ b/test/image_test.cpp
@@ -4,6 +4,10 @@
 extern "C" {
 #include "buildcfg.h"
 #include "image.h"
+
+#ifdef HAVE_LIBRSVG
+#include "formats/svg.h"
+#endif
 }
 
 #include <gtest/gtest.h>
@@ -105,6 +109,29 @@ TEST_F(Image, LoadFromExec)
     ASSERT_TRUE(image);
     ASSERT_EQ(image_load(image), imgload_success);
 }
+
+#ifdef HAVE_LIBRSVG
+TEST_F(Image, RescaleSVG)
+{
+    Load(TEST_DATA_DIR "/image.svg");
+    ASSERT_TRUE(image->frames[0].pm.height == 1024);
+    ASSERT_TRUE(image->frames[0].pm.width == 1024);
+
+    adjust_svg_render_size(1.5);
+
+    image_free(image, IMGFREE_FRAMES);
+    Load(TEST_DATA_DIR "/image.svg");
+    ASSERT_TRUE(image->frames[0].pm.height == 1536);
+    ASSERT_TRUE(image->frames[0].pm.width == 1536);
+
+    reset_svg_render_size();
+
+    image_free(image, IMGFREE_FRAMES);
+    Load(TEST_DATA_DIR "/image.svg");
+    ASSERT_TRUE(image->frames[0].pm.height == 1024);
+    ASSERT_TRUE(image->frames[0].pm.width == 1024);
+}
+#endif // HAVE_LIBRSVG
 
 #define TEST_LOADER(n)                    \
     TEST_F(Image, Load_##n)               \


### PR DESCRIPTION
This PR adds a new keybinding (`Alt+R`), which rerenders the currently displayed SVG at the current scale level:

**Before (blurry zoomed-in view):**

![2025-05-05-135625_hyprshot](https://github.com/user-attachments/assets/b73ee015-bdf1-4f6b-b008-7956c33e433b)

**After (rendered at current scale):**

![2025-05-05-135913_hyprshot](https://github.com/user-attachments/assets/24d553fe-bf1b-4978-9ba3-6f069c11c68a)

I essentially just added the keybinding and created two functions to set and reset the scaling factor for the SVG module. When `Alt+R` is pressed in the viewer, the new scaling factor is applied and the image is reloaded (similar as is done in `reload_current()`, but no position change).

The scaling factor is reset when a new file is loaded. A more elegant solution would be to save this on a per-image basis, but that would introduce image-type-specific variables to the context. I chose the current approach for simplicity and to avoid architectural changes.

I’m still learning the ropes with PRs, so please let me know if there’s anything I can improve.
=> 1. lesson learned: enable pipelines on the fork before creating a PR