### PR TITLE
Add rotate/flip for custom decoder

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -210,29 +210,45 @@ bool image_has_info(const struct image* img)
 
 void image_flip_vertical(struct image* img)
 {
-    struct array* frames = img->data->frames;
-    for (size_t i = 0; i < frames->size; ++i) {
-        struct imgframe* frame = arr_nth(frames, i);
-        pixmap_flip_vertical(&frame->pm);
+    if (img->data->decoder.flip) {
+        // image specific flip
+        img->data->decoder.flip(img->data, true);
+    } else {
+        struct array* frames = img->data->frames;
+        for (size_t i = 0; i < frames->size; ++i) {
+            struct imgframe* frame = arr_nth(frames, i);
+            pixmap_flip_vertical(&frame->pm);
+        }
     }
 }
 
 void image_flip_horizontal(struct image* img)
 {
-    struct array* frames = img->data->frames;
-    for (size_t i = 0; i < frames->size; ++i) {
-        struct imgframe* frame = arr_nth(frames, i);
-        pixmap_flip_horizontal(&frame->pm);
+    if (img->data->decoder.flip) {
+        // image specific flip
+        img->data->decoder.flip(img->data, false);
+    } else {
+        struct array* frames = img->data->frames;
+        for (size_t i = 0; i < frames->size; ++i) {
+            struct imgframe* frame = arr_nth(frames, i);
+            pixmap_flip_horizontal(&frame->pm);
+        }
     }
 }
 
 void image_rotate(struct image* img, size_t angle)
 {
     assert(angle == 90 || angle == 180 || angle == 270);
-    struct array* frames = img->data->frames;
-    for (size_t i = 0; i < frames->size; ++i) {
-        struct imgframe* frame = arr_nth(frames, i);
-        pixmap_rotate(&frame->pm, angle);
+
+    if (img->data->decoder.rotate) {
+        // image specific rotate
+        img->data->decoder.rotate(img->data, angle);
+    } else {
+        struct array* frames = img->data->frames;
+        for (size_t i = 0; i < frames->size; ++i) {
+            struct imgframe* frame = arr_nth(frames, i);
+            pixmap_rotate(&frame->pm, angle);
+        }
     }
 }
 

--- a/src/image.h
+++ b/src/image.h
@@ -41,6 +41,21 @@ struct imgdec {
      */
     void (*render)(struct imgdata* img, double scale, ssize_t x, ssize_t y,
                    struct pixmap* dst);
+
+    /**
+     * Custom flip function.
+     * @param img image container
+     * @param vertical set to true for vertical flip, otherwise horizontal
+     */
+    void (*flip)(struct imgdata* img, bool vertical);
+
+    /**
+     * Custom rotate function.
+     * @param img image container
+     * @param angle rotation angle (only 90, 180, 270)
+     */
+    void (*rotate)(struct imgdata* img, size_t angle);
+
     /**
      * Free decoder internal data.
      * @param img image container


### PR DESCRIPTION
Adds additional rotate and flip handlers for custom decoders and implements them for the SVG format.
In reference to #279.