### PR TITLE
Remove mention of `-R/--reverse` from man

### DIFF
--- a/extra/swayimg.1
+++ b/extra/swayimg.1
@@ -50,9 +50,6 @@ Set order of the image list:
 \fIsize\fR: sorted by file size;
 \fIrandom\fR: randomize list.
 .\" ----------------------------------------------------------------------------
-.IP "\fB\-R\fR, \fB\-\-reverse\fR"
-Reverse sorted order.
-.\" ----------------------------------------------------------------------------
 .IP "\fB\-s\fR, \fB\-\-scale\fR=\fIMODE\fR"
 Set the default image scale, valid modes are:
 .nf


### PR DESCRIPTION
This option is not handled by the CLI.
It was a leftover from #264 where the implementation was found to be [confusing](https://github.com/artemsen/swayimg/pull/264#discussion_r2000410307).