### PR TITLE
Fix out-of-memory error code from shellcmd.c read_stream function

### DIFF
--- a/src/shellcmd.c
+++ b/src/shellcmd.c
@@ -36,13 +36,13 @@ static int read_stream(int fd, struct array** data)
         if (*data) {
             struct array* arr = arr_append(*data, buf, read_sz);
             if (!arr) {
-                return ENOMEM;
+                return -ENOMEM;
             }
             *data = arr;
         } else {
             *data = arr_create(read_sz, sizeof(uint8_t));
             if (!*data) {
-                return ENOMEM;
+                return -ENOMEM;
             }
             memcpy(arr_nth(*data, 0), buf, read_sz);
         }


### PR DESCRIPTION
The `read_stream` function is supposed to return a negative error code on failure, and it already correctly returns `-errno` on read errors, but it can also return (the positive value) `ENOMEM` if memory allocation failed for storing the output. Returning `-ENOMEM` instead to be consistent and make those errors distinguishable.