### PR TITLE
Gallery mode by default for multiple files

### DIFF
--- a/src/application.c
+++ b/src/application.c
@@ -255,6 +255,12 @@ bool app_init(const struct config* cfg, const char* const* sources, size_t num)
                                  ARRAY_SIZE(mode_names));
     ctx.mprev = mode_viewer;
 
+    // set mode to gallery if current mode is not default and
+    // the imglist is multiple images for expected usage
+    if (imglist_size() > 1 && ctx.mcurr != ctx.mprev) {
+        ctx.mcurr = mode_gallery;
+    }
+
     // create event queue notification
     ctx.event_signal = fdevent_add(handle_event_queue, NULL);
     if (ctx.event_signal < 0) {


### PR DESCRIPTION
calling swayimg for multiple files or a directory doesn't always mean that the user wants to view only the first file, instead, the user would want to view multiple files in a gallery view.

inversing the immediate mode switch to gallery for those who want to view each individual file is better because they would know they chose the correct files as well.