### PR TITLE
Add option to change info text padding

### DIFF
--- a/extra/swayimgrc
+++ b/extra/swayimgrc
@@ -134,6 +134,8 @@ background = #00000000
 [info]
 # Show on startup (yes/no)
 show = yes
+# Text padding from window edges
+padding = 10
 # Timeout to hide info (seconds, 0 to always show)
 info_timeout = 5
 # Timeout to hide status message (seconds)

--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "SWAYIMGRC" "5" "2025-07-07" "swayimg" "Swayimg configuration"
+.TH "SWAYIMGRC" "5" "2025-07-10" "swayimg" "Swayimg configuration"
 .PP
 .SH NAME
 .PP
@@ -422,6 +422,11 @@ General configuration of the displayed text layer: \fI[info]\fR.\&
 \fBshow\fR = \fIyes\fR|\fIno\fR
 .RS 4
 Enable or disable info text at startup, \fIyes\fR by default.\&
+.PP
+.RE
+\fBpadding\fR = PADDING
+.RS 4
+Text padding from window edges (in px), \fI10\fR by default.\&
 .PP
 .RE
 \fBinfo_timeout\fR = SECONDS

--- a/extra/swayimgrc.5.scd
+++ b/extra/swayimgrc.5.scd
@@ -261,6 +261,9 @@ General configuration of the displayed text layer: _[info]_.
 *show* = _yes_|_no_
 	Enable or disable info text at startup, _yes_ by default.
 
+*padding* = PADDING
+	Text padding from window edges (in px), _10_ by default.
+
 *info_timeout* = SECONDS
 	Timeout of image information displayed on the screen, _0_ to always show,
 	_5_ by default.

--- a/src/config.c
+++ b/src/config.c
@@ -86,6 +86,7 @@ static const struct configdef_kv def_font[] = {
 
 static const struct configdef_kv def_info[] = {
     { CFG_INFO_SHOW,      CFG_YES     },
+    { CFG_INFO_PADDING,   "10"        },
     { CFG_INFO_ITIMEOUT,  "5"         },
     { CFG_INFO_STIMEOUT,  "3"         },
 };

--- a/src/config.h
+++ b/src/config.h
@@ -81,6 +81,7 @@ struct config {
 #define CFG_FONT_BKG       "background"
 #define CFG_FONT_SHADOW    "shadow"
 #define CFG_INFO_SHOW      "show"
+#define CFG_INFO_PADDING   "padding"
 #define CFG_INFO_ITIMEOUT  "info_timeout"
 #define CFG_INFO_STIMEOUT  "status_timeout"
 #define CFG_INFO_TL        "top_left"


### PR DESCRIPTION
Adds new option: "info.padding", to change the previously hard-coded text padding within info view.

Other hard-coded values should also be taken into consideration. If those should be added as options, I'm more than willing to also contribute those. 

Hard-coded values aren't nice :<