### PR TITLE
attempted fix of windowrule syntax for hyprland

### DIFF
--- a/src/ui/compositor.c
+++ b/src/ui/compositor.c
@@ -298,6 +298,15 @@ static bool hyprland_overlay(const struct wndrect* wnd, char** app_id)
     }
     json_object_put(response);
 
+    // set size
+    snprintf(buf, sizeof(buf), "keyword windowrule size %zd %zd, match:class %s",
+            wnd->width, wnd->height, *app_id);
+    response = hyprland_request(buf);
+    if (!response) {
+        return false;
+    }
+    json_object_put(response);
+
     return true;
 }
 


### PR DESCRIPTION
<img width="1920" height="1198" alt="image" src="https://github.com/user-attachments/assets/5ff49ba6-b476-467e-8263-f7e7c41e12f7" />

So far, this PR changes the syntax of windowrules in the compositor.c file (just two lines!) to match the latest hyprland release. This allows the automatic placement and floating overlay behavior of swayimg to be restored, for users who enable it.

However, something is wrong with the sizing. As you can see in the image, swayimg is consistently half the size it should be, with slight overhangs. My theory is that

> It may be that the dimensions of swayimg itself are being passed back into swayimg when it is deciding its sizing, if somehow the window is being spawned before dimensions are calculated, but I understand far too little of the two compositor files to say so definitely <.<

But as I say here I am not certain >.<

At any rate, this is less of a regression than the current state of swayimg, where overlays do not occur at all due to the syntax changes in hyprland: see https://github.com/artemsen/swayimg/issues/364 for more details.

Due to the above, while this PR should be fine on its own, help figuring out what is causing either

a) the `compositor.c` function to grab hyprland client dimensions
b) the `compositor.h` function to resize the swayimg window

to function improperly (at least I think that is the case) on hyprland, or test the PR on their own machine, that would be awesome ^^

(I am still very new to github, sorry if any of this is improper)