### PR TITLE
info: add toggle mode cycling with customizable mode lists

### DIFF
--- a/extra/swayimgrc.5.scd
+++ b/extra/swayimgrc.5.scd
@@ -509,13 +509,15 @@ Predefined names for mouse buttons/scroll:
 	- empty value to toggle AA on/off.
 
 *info* [MODE]
-	Set text info mode or cycle through them, _MODE_ is:
-	- one of the configured schemes: _off_/_viewer_/_slideshow_/_gallery_;
-	- empty value to switch to the next configured mode;
-	- _toggle_ [LIST] to cycle through a custom list of modes, where _LIST_ is
-	  a slash-separated list (e.g. _viewer/off_). Each entry must be either
-	  _off_ or the name of a configured scheme.
-	  If _LIST_ is omitted, the default list is: _off/viewer/gallery_.
+	Switch or cycle text info modes.
+
+	With no _MODE_, the mode cycles through: _off_/_viewer_/_slideshow_/_gallery_.
+
+	If _MODE_ is a single mode name (e.g. _viewer_), switch to that mode.
+	If _MODE_ is a comma-separated list (e.g. _viewer,off_), cycle through the
+	listed modes. Spaces around commas are ignored.
+
+	Each entry must be either _off_ or the name of a configured scheme.
 
 *exec* COMMAND
 	Execute an external command, use % to substitute the full path to the

--- a/src/info.h
+++ b/src/info.h
@@ -41,7 +41,7 @@ void info_destroy(void);
 
 /**
  * Switch info scheme.
- * @param expression scheme name or toggle expression
+ * @param expression scheme name or comma-separated cycling expression
  */
 void info_switch(const char* expression);
 


### PR DESCRIPTION
## Description
Extend info to support support comma-separated mode cycling.

* `info` (no expression) cycles through the default list: `off/viewer/slideshow/gallery`
* `info MODE` switches directly to the specified mode
* `info MODE,MODE,...` cycles through the provided comma-separated mode list

Documentation has been updated to reflect the new syntax and examples.

## Use Case
Press `i` to show minimal info in viewer, and hide it everywhere else, you want:

* In viewer mode: `i` toggles info overlay between `viewer` and `off` (so you can quickly peek at filename/size/etc.).
* In gallery mode: `i` toggles between `gallery` and `off` (so it doesn't switch you into the viewer overlay style).

```
[keys.viewer]
i = info viewer,off

[keys.gallery]
i = info gallery,off
```

Result: The same key (`i`) acts as a context-aware "info overlay toggle" depending on where you are, without cycling through modes you don’t want.