### PR TITLE
viewer,gallery: add drag_and_drop action

### DIFF
--- a/extra/swayimgrc
+++ b/extra/swayimgrc
@@ -235,6 +235,7 @@ Shift+ScrollDown = next_file
 Alt+ScrollUp = prev_frame
 Alt+ScrollDown = next_frame
 MouseLeft = drag
+# MouseMiddle = drag_and_drop
 MouseSide = prev_file
 MouseExtra = next_file
 
@@ -291,3 +292,4 @@ ScrollDown = step_down
 Ctrl+ScrollUp = thumb +20
 Ctrl+ScrollDown = thumb -20
 MouseLeft = mode viewer
+# MouseMiddle = drag_and_drop

--- a/extra/swayimgrc.5
+++ b/extra/swayimgrc.5
@@ -846,6 +846,12 @@ Mouse buttons in viewer mode only.\&
 Set the button for drag operation.\&
 .PP
 .RE
+\fBdrag_and_drop\fR
+.RS 4
+Mouse buttons in viewer/gallery modes only.\&
+Start drag and drop operation for the current image file.\&
+.PP
+.RE
 \fBexport\fR FILE
 .RS 4
 Viewer mode only.\&

--- a/extra/swayimgrc.5.scd
+++ b/extra/swayimgrc.5.scd
@@ -532,6 +532,10 @@ Predefined names for mouse buttons/scroll:
 	Mouse buttons in viewer mode only.
 	Set the button for drag operation.
 
+*drag_and_drop*
+	Mouse buttons in viewer/gallery modes only.
+	Start drag and drop operation for the current image file.
+
 *export* FILE
 	Viewer mode only.
 	Export currently displayed image to PNG file.

--- a/src/action.c
+++ b/src/action.c
@@ -46,6 +46,7 @@ static const char* action_names[] = {
     [action_reload] = "reload",
     [action_redraw] = "redraw",
     [action_drag] = "drag",
+    [action_drag_and_drop] = "drag_and_drop",
     [action_antialiasing] = "antialiasing",
     [action_info] = "info",
     [action_exec] = "exec",

--- a/src/action.h
+++ b/src/action.h
@@ -40,6 +40,7 @@ enum action_type {
     action_reload,
     action_redraw,
     action_drag,
+    action_drag_and_drop,
     action_antialiasing,
     action_info,
     action_exec,

--- a/src/application.c
+++ b/src/application.c
@@ -445,3 +445,11 @@ void app_apply_action(const struct action* action, bool fau)
     // raise notification
     fdevent_set(ctx.event_signal);
 }
+
+const struct image* app_current_image(void)
+{
+    if (!ctx.modes[ctx.mcurr].get_current) {
+        return NULL;
+    }
+    return ctx.modes[ctx.mcurr].get_current();
+}

--- a/src/application.h
+++ b/src/application.h
@@ -108,3 +108,9 @@ void app_on_keyboard(xkb_keysym_t key, uint8_t mods);
  * @param fau flag to free action after execution
  */
 void app_apply_action(const struct action* action, bool fau);
+
+/**
+ * Get currently showed/selected image.
+ * @return current image instance
+ */
+const struct image* app_current_image(void);

--- a/src/gallery.c
+++ b/src/gallery.c
@@ -629,9 +629,24 @@ static bool on_mouse_click(uint8_t mods, uint32_t btn, size_t x, size_t y)
 {
     const struct keybind* kb = keybind_find(ctx.kb, MOUSE_TO_XKB(btn), mods);
     if (kb && kb->actions->type == action_mode) {
-        if (layout_get_at(&ctx.layout, x, y)) {
-            app_switch_mode(kb->actions->params);
+        if (!layout_get_at(&ctx.layout, x, y)) {
+            return true;
         }
+        app_switch_mode(kb->actions->params);
+        return true;
+    }
+    if (kb && kb->actions->type == action_drag_and_drop) {
+        if (!layout_get_at(&ctx.layout, x, y)) {
+            return true;
+        }
+        if (layout_select_at(&ctx.layout, x, y)) {
+            info_reset(ctx.layout.current);
+            ui_set_title(ctx.layout.current->name);
+            info_update_index(info_index, ctx.layout.current->index,
+                              imglist_size());
+            app_redraw();
+        }
+        ui_set_cursor(ui_cursor_drag_and_drop);
         return true;
     }
     return false;

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -18,6 +18,7 @@
 enum ui_cursor {
     ui_cursor_default,
     ui_cursor_drag,
+    ui_cursor_drag_and_drop,
     ui_cursor_hide,
 };
 

--- a/src/ui/wayland.c
+++ b/src/ui/wayland.c
@@ -18,7 +18,9 @@
 #include "xdg-decoration-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
+#include <ctype.h>
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -39,6 +41,12 @@
 // Timeout to hide cursor
 #define CURSOR_HIDE_TIMEOUT 3 // sec
 
+// DnD mime types
+#define MIME_URI_LIST   "text/uri-list"
+#define MIME_TEXT_UTF8  "text/plain;charset=utf-8"
+#define MIME_TEXT_PLAIN "text/plain"
+#define MIME_GNOME_COPY "x-special/gnome-copied-files"
+
 /** Wayland context. */
 struct wayland {
     // wayland objects
@@ -52,6 +60,8 @@ struct wayland {
         struct wl_pointer* pointer;
         struct wl_surface* surface;
         struct wl_output* output;
+        struct wl_data_device_manager* data_device_manager;
+        struct wl_data_device* data_device;
     } wl;
 
     // wayland protocols objects
@@ -110,12 +120,160 @@ struct wayland {
         int y;
     } mouse;
 
+    // drag and drop payload
+    struct dnd {
+        struct wl_data_source* source;
+        char* file_uri;
+        char* file_path;
+        char* gnome_copy;
+    } dnd;
+
     // fullscreen mode
     bool fullscreen;
 
     // flag to cancel event queue
     bool event_handled;
 };
+
+/**
+ * Release current DnD payload.
+ * @param ctx UI context
+ */
+static void dnd_payload_reset(struct wayland* ctx)
+{
+    free(ctx->dnd.file_uri);
+    free(ctx->dnd.file_path);
+    free(ctx->dnd.gnome_copy);
+    ctx->dnd.file_uri = NULL;
+    ctx->dnd.file_path = NULL;
+    ctx->dnd.gnome_copy = NULL;
+}
+
+/**
+ * URI escape file path.
+ * @param path source file path
+ * @return escaped URI path or NULL on errors
+ */
+static char* uri_escape_path(const char* path)
+{
+    size_t len = 0;
+    size_t esc_len = 0;
+    char* out;
+    char* dst;
+
+    while (path[len]) {
+        const unsigned char ch = (unsigned char)path[len];
+        if (isalnum(ch) || ch == '/' || ch == '-' || ch == '_' || ch == '.' ||
+            ch == '~') {
+            esc_len += 1;
+        } else {
+            esc_len += 3;
+        }
+        ++len;
+    }
+
+    out = malloc(esc_len + 1);
+    if (!out) {
+        return NULL;
+    }
+
+    dst = out;
+    for (size_t i = 0; i < len; ++i) {
+        const unsigned char ch = (unsigned char)path[i];
+        if (isalnum(ch) || ch == '/' || ch == '-' || ch == '_' || ch == '.' ||
+            ch == '~') {
+            *dst++ = ch;
+        } else {
+            dst += snprintf(dst, 4, "%%%02X", ch);
+        }
+    }
+    *dst = 0;
+
+    return out;
+}
+
+/**
+ * Write complete buffer to file descriptor.
+ * @param fd target descriptor
+ * @param data buffer to write
+ */
+static void write_to_fd(int fd, const char* data)
+{
+    size_t left = strlen(data);
+
+    while (left) {
+        const ssize_t rc = write(fd, data, left);
+        if (rc < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            break;
+        }
+        if (rc == 0) {
+            break;
+        }
+        left -= rc;
+        data += rc;
+    }
+}
+
+/**
+ * Build drag-n-drop payload for currently shown image file.
+ * @param ctx UI context
+ * @return true if payload built successfully
+ */
+static bool dnd_build_payload(struct wayland* ctx)
+{
+    const struct image* image = app_current_image();
+    const char* source;
+    char* escaped;
+
+    dnd_payload_reset(ctx);
+
+    if (!image || !image->source) {
+        return false;
+    }
+
+    source = image->source;
+    if (strncmp(source, LDRSRC_STDIN, LDRSRC_STDIN_LEN) == 0 ||
+        strncmp(source, LDRSRC_EXEC, LDRSRC_EXEC_LEN) == 0) {
+        return false;
+    }
+    if (*source != '/') {
+        return false;
+    }
+
+    ctx->dnd.file_path = str_dup(source, NULL);
+    if (!ctx->dnd.file_path) {
+        dnd_payload_reset(ctx);
+        return false;
+    }
+
+    escaped = uri_escape_path(source);
+    if (!escaped) {
+        dnd_payload_reset(ctx);
+        return false;
+    }
+    str_append("file://", 0, &ctx->dnd.file_uri);
+    str_append(escaped, 0, &ctx->dnd.file_uri);
+    free(escaped);
+
+    if (!ctx->dnd.file_uri) {
+        dnd_payload_reset(ctx);
+        return false;
+    }
+
+    str_append("copy\n", 0, &ctx->dnd.gnome_copy);
+    str_append(ctx->dnd.file_uri, 0, &ctx->dnd.gnome_copy);
+    str_append("\n", 0, &ctx->dnd.gnome_copy);
+
+    if (!ctx->dnd.gnome_copy) {
+        dnd_payload_reset(ctx);
+        return false;
+    }
+
+    return true;
+}
 
 /**
  * Recreate window buffers.
@@ -235,6 +393,140 @@ static void on_keyboard_key(void* data, struct wl_keyboard* wl_keyboard,
     }
 }
 
+/*******************************************************************************
+ * Drag and Drop handlers
+ ******************************************************************************/
+static void on_data_source_target(void* data, struct wl_data_source* source,
+                                  const char* mime_type)
+{
+}
+
+static void on_data_source_send(void* data, struct wl_data_source* source,
+                                const char* mime_type, int32_t fd)
+{
+    struct wayland* ctx = data;
+
+    if (strcmp(mime_type, MIME_URI_LIST) == 0) {
+        write_to_fd(fd, ctx->dnd.file_uri);
+        write_to_fd(fd, "\r\n");
+    } else if (strcmp(mime_type, MIME_TEXT_UTF8) == 0 ||
+               strcmp(mime_type, MIME_TEXT_PLAIN) == 0) {
+        write_to_fd(fd, ctx->dnd.file_path);
+        write_to_fd(fd, "\n");
+    } else if (strcmp(mime_type, MIME_GNOME_COPY) == 0) {
+        write_to_fd(fd, ctx->dnd.gnome_copy);
+    }
+
+    close(fd);
+}
+
+static void on_data_source_cancelled(void* data, struct wl_data_source* source)
+{
+    struct wayland* ctx = data;
+    if (ctx->dnd.source) {
+        wl_data_source_destroy(ctx->dnd.source);
+        ctx->dnd.source = NULL;
+    }
+    dnd_payload_reset(ctx);
+}
+
+static void on_data_source_dnd_drop_performed(void* data,
+                                              struct wl_data_source* source)
+{
+}
+
+static void on_data_source_dnd_finished(void* data, struct wl_data_source* source)
+{
+}
+
+static void on_data_source_action(void* data, struct wl_data_source* source,
+                                  uint32_t dnd_action)
+{
+}
+
+static const struct wl_data_source_listener data_source_listener = {
+    .target = on_data_source_target,
+    .send = on_data_source_send,
+    .cancelled = on_data_source_cancelled,
+    .dnd_drop_performed = on_data_source_dnd_drop_performed,
+    .dnd_finished = on_data_source_dnd_finished,
+    .action = on_data_source_action,
+};
+
+static void on_data_device_data_offer(void* data, struct wl_data_device* device,
+                                      struct wl_data_offer* offer)
+{
+    wl_data_offer_destroy(offer);
+}
+
+static void on_data_device_enter(void* data, struct wl_data_device* device,
+                                 uint32_t serial, struct wl_surface* surface,
+                                 wl_fixed_t x, wl_fixed_t y,
+                                 struct wl_data_offer* id)
+{
+}
+
+static void on_data_device_leave(void* data, struct wl_data_device* device) { }
+
+static void on_data_device_motion(void* data, struct wl_data_device* device,
+                                  uint32_t time, wl_fixed_t x, wl_fixed_t y)
+{
+}
+
+static void on_data_device_drop(void* data, struct wl_data_device* device) { }
+
+static void on_data_device_selection(void* data, struct wl_data_device* device,
+                                     struct wl_data_offer* offer)
+{
+}
+
+static const struct wl_data_device_listener data_device_listener = {
+    .data_offer = on_data_device_data_offer,
+    .enter = on_data_device_enter,
+    .leave = on_data_device_leave,
+    .motion = on_data_device_motion,
+    .drop = on_data_device_drop,
+    .selection = on_data_device_selection,
+};
+
+/**
+ * Start drag-n-drop operation.
+ * @param ctx UI context
+ * @param serial serial from pointer button event
+ * @return true if DnD successfully started
+ */
+static bool start_dnd(struct wayland* ctx, uint32_t serial)
+{
+    if (!ctx->wl.data_device_manager || !ctx->wl.data_device) {
+        return false;
+    }
+    if (!dnd_build_payload(ctx)) {
+        return false;
+    }
+
+    if (ctx->dnd.source) {
+        wl_data_source_destroy(ctx->dnd.source);
+        ctx->dnd.source = NULL;
+    }
+
+    ctx->dnd.source =
+        wl_data_device_manager_create_data_source(ctx->wl.data_device_manager);
+    if (!ctx->dnd.source) {
+        dnd_payload_reset(ctx);
+        return false;
+    }
+
+    wl_data_source_add_listener(ctx->dnd.source, &data_source_listener, ctx);
+    wl_data_source_offer(ctx->dnd.source, MIME_URI_LIST);
+    wl_data_source_offer(ctx->dnd.source, MIME_TEXT_UTF8);
+    wl_data_source_offer(ctx->dnd.source, MIME_TEXT_PLAIN);
+    wl_data_source_offer(ctx->dnd.source, MIME_GNOME_COPY);
+
+    wl_data_device_start_drag(ctx->wl.data_device, ctx->dnd.source,
+                              ctx->wl.surface, NULL, serial);
+    return true;
+}
+
 static void on_pointer_enter(void* data, struct wl_pointer* wl_pointer,
                              uint32_t serial, struct wl_surface* surface,
                              wl_fixed_t surface_x, wl_fixed_t surface_y)
@@ -304,6 +596,13 @@ static void on_pointer_button(void* data, struct wl_pointer* wl_pointer,
             const uint8_t mods = keybind_mods(ctx->xkb.state);
             ctx->mouse.button |= btn;
             app_on_mclick(mods, ctx->mouse.button, ctx->mouse.x, ctx->mouse.y);
+
+            if (ctx->mouse.shape == ui_cursor_drag_and_drop &&
+                start_dnd(ctx, serial)) {
+                // The compositor handles drag cursor and motion while dragging.
+                ctx->mouse.button &= ~btn;
+                ui_set_cursor(ui_cursor_default);
+            }
         }
     }
 }
@@ -379,6 +678,14 @@ static void on_seat_capabilities(void* data, struct wl_seat* seat, uint32_t cap)
     } else if (ctx->wl.pointer) {
         wl_pointer_destroy(ctx->wl.pointer);
         ctx->wl.pointer = NULL;
+    }
+
+    if (ctx->wl.data_device_manager && !ctx->wl.data_device) {
+        ctx->wl.data_device =
+            wl_data_device_manager_get_data_device(ctx->wl.data_device_manager,
+                                                   seat);
+        wl_data_device_add_listener(ctx->wl.data_device, &data_device_listener,
+                                    ctx);
     }
 
     // register idle listener
@@ -524,6 +831,12 @@ static void on_registry_global(void* data, struct wl_registry* registry,
                                         WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION);
         wl_seat_add_listener(ctx->wl.seat, &seat_listener, data);
 
+    } else if (strcmp(interface, wl_data_device_manager_interface.name) == 0) {
+        // drag-and-drop + clipboard data device
+        ctx->wl.data_device_manager = wl_registry_bind(
+            registry, name, &wl_data_device_manager_interface,
+            WL_DATA_DEVICE_MANAGER_GET_DATA_DEVICE_SINCE_VERSION);
+
     } else if (strcmp(interface, ext_idle_notifier_v1_interface.name) == 0) {
         // idle notifier
         ctx->wp.idle_manager =
@@ -658,17 +971,18 @@ static void wayland_set_cursor(void* data, enum ui_cursor shape)
     enum wp_cursor_shape_device_v1_shape wlshape;
     struct wp_cursor_shape_device_v1* dev;
 
+    ctx->mouse.shape = shape;
+
     if (!ctx->wl.pointer || !ctx->wp.cursor) {
         return;
     }
-
-    ctx->mouse.shape = shape;
 
     switch (shape) {
         case ui_cursor_hide:
             wl_pointer_set_cursor(ctx->wl.pointer, 0, NULL, 0, 0);
             return;
         case ui_cursor_drag:
+        case ui_cursor_drag_and_drop:
             wlshape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_GRABBING;
             break;
         case ui_cursor_default:
@@ -796,7 +1110,18 @@ static void wayland_free(void* data)
     wndbuf_free(ctx->wnd.buffer0);
     wndbuf_free(ctx->wnd.buffer1);
 
+    if (ctx->dnd.source) {
+        wl_data_source_destroy(ctx->dnd.source);
+    }
+    dnd_payload_reset(ctx);
+
     // base wayland
+    if (ctx->wl.data_device) {
+        wl_data_device_destroy(ctx->wl.data_device);
+    }
+    if (ctx->wl.data_device_manager) {
+        wl_data_device_manager_destroy(ctx->wl.data_device_manager);
+    }
     if (ctx->wl.seat) {
         wl_seat_destroy(ctx->wl.seat);
     }
@@ -857,6 +1182,13 @@ void* ui_init_wl(const char* app_id, size_t width, size_t height, bool decor,
     }
     wl_registry_add_listener(ctx->wl.registry, &registry_listener, ctx);
     wl_display_roundtrip(ctx->wl.display);
+
+    if (ctx->wl.data_device_manager && ctx->wl.seat && !ctx->wl.data_device) {
+        ctx->wl.data_device = wl_data_device_manager_get_data_device(
+            ctx->wl.data_device_manager, ctx->wl.seat);
+        wl_data_device_add_listener(ctx->wl.data_device, &data_device_listener,
+                                    ctx);
+    }
 
     ctx->wl.surface = wl_compositor_create_surface(ctx->wl.compositor);
     if (!ctx->wl.surface) {

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -563,6 +563,10 @@ static bool on_mouse_click(uint8_t mods, uint32_t btn,
         ui_set_cursor(ui_cursor_drag);
         return true;
     }
+    if (kb && kb->actions->type == action_drag_and_drop) {
+        ui_set_cursor(ui_cursor_drag_and_drop);
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
Add drag_and_drop action to gallery and viewer modes. Add/replace `MouseLeft = drag_and_drop` (or any other mouse keybinds) in the config to enable.

Quick demo video:
https://github.com/user-attachments/assets/ac26bc94-47d2-48b7-be99-432956b87d91

I found drag and drop is the main reason I still have to open a file manager these days. Thought I'd love to have this available through swayimg and had codex give it a try. It worked (surprisingly) so I cleaned it up a bit and added a config option. It passes all the checks in GH CI in my fork.

It's a large-ish change to the codebase, so not sure whether this is something worth adding/maintaining. Let me know!