### PR TITLE
image from stdin

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -263,7 +263,11 @@ int main(int argc, char* argv[])
     }
 
     for (int i = argn; i < argc; ++i) {
-        Application::self().sparams.sources.push_back(argv[i]);
+        std::string arg = argv[i];
+        if (arg == "-") {
+            arg = ImageEntry::SRC_STDIN;  // Convert "-" to "stdin://"
+        }
+        Application::self().sparams.sources.push_back(arg);
     }
 
     return Application::self().run();


### PR DESCRIPTION
Currently swayimg does not load image from stdin. This fixes the issue and loads image from stdin.
```
screenshot --stdout | swayimg -
```