### PR TITLE
feat(lua): api v2 with implementation of a conversion layer

### DIFF
--- a/extra/swayimg.lua
+++ b/extra/swayimg.lua
@@ -164,12 +164,12 @@ local mode_base = {}
 
 ---Map a keyboard event to an action.
 ---@param bind string|string[] 1 or more mouse or keyboard events to map - `Alt+s`, etc.
----@param cb string|fun() shellcmd to execute (% for current image) or callback function to run
+---@param cb fun() callback function to run
 function mode_base.on_key(bind, cb) end
 
 ---Map a mouse event to an action.
 ---@param bind string|string[] 1 or more mouse or keyboard events to map - `Ctrl+ScrollDown`, etc.
----@param cb string|fun() shellcmd to execute (% for current image) or callback function to run
+---@param cb fun() callback function to run
 function mode_base.on_mouse(bind, cb) end
 
 ---Remove all existing key/mouse/signal bindings.


### PR DESCRIPTION
hacks in #403 

Changes:
- removed `set_meta` since now if the image metadata actually changes, the object gets updated
  - this enforces that no fake metadata is set that is not actually in the file
- moved `set_status` under `text.set_status` because that's where the `status_timer` is already and it is related
- made all hook callbacks removable (`on_image_change`,`on_signal`,`on_window_resize`)
- joined `on_key` and `on_mouse` bindings into a typical `map()` function
- added a user-friendly shell `exec` function to mimic the old one from `ini` config
- renamed `viewer.open` to `viewer.select` to be consistent with `gallery` and be more representative of the actual action (we're not launching xdg-open or sth else to open the image, we're just selecting a different image in the current window)
- `imagelist.mark` -> `imagelist.mark_current`
- renamed img attribute `mark` to `marked` because the mark is not a string but a toggle
- moved `xxx.current_image` to `imagelist.get_current` since the other getter is there too and renamed `viewer.current_image` to `viewer.get_loaded_image`
- joined text timer manipulation to set a bool or number and remove `hide/show()`
- everything volatile stays as methods, the rest got converted to variables, meaning all will need a getter, too
- I provided a fully functional conversion layer that overcomes the missing getters by caching the last-set value to be able to read it.

Note: I used AI to help with the conversion layer and the docs, but I checked then myself that nothing is missing (except the intentional `set_meta` removal) and methods work. But it is always possible I've overlooked sth.