### PR TITLE
fix: remove hardcoded Background::Auto override in Slideshow constructor

### DIFF
--- a/src/slideshow.cpp
+++ b/src/slideshow.cpp
@@ -17,7 +17,6 @@ Slideshow::Slideshow()
     // default settings
 
     set_history_limit(0);
-    set_window_background(Background::Auto);
     default_scale = Scale::FitWindow;
 
     text_scheme[static_cast<size_t>(Text::TopLeft)] = { "{name}" };


### PR DESCRIPTION
issue #409  

The Slideshow constructor was unconditionally calling
set_window_background(Background::Auto), which forced the slideshow
mode to always display a blurred/mirrored background regardless of
user configuration. Since Slideshow and Viewer are separate singletons,
any window background color set via swayimg.viewer.set_window_background()
only affected the Viewer instance, while the Slideshow instance always
reverted to Background::Auto.
 
By removing this hardcoded override, the Slideshow now inherits the
default window background from its Viewer base class (solid black),
and respects user-configured background settings applied through
swayimg.slideshow.set_window_background().


The CI build failed due to a clang/glib compatibility issue in src/formats/svg.cpp (C2y extensions error), which is unrelated to my changes in src/slideshow.cpp, i just delete a line