### PR TITLE
fix: refresh list.total count when images are added

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -460,6 +460,10 @@ void Application::handle_event(const AppEvent::FileCreate& event)
     } else {
         entries = il.add(event.path);
     }
+    if (active_mode == Mode::Viewer) {
+        const ImageEntryPtr current = Viewer::self().current_entry();
+        Viewer::self().open_file(ImageList::Dir::First, current);
+    }
     for (auto& it : entries) {
         current_mode()->handle_imagelist(AppMode::ImageListEvent::Create, it);
     }


### PR DESCRIPTION
# From issue #414

## The Problem
When opening a single image with `adjacent` file scanning disabled (the default or via `swayimg.imagelist.enable_adjacent(false)`), the `ImageList` is initialized with a size of **1**. 

If a Lua script subsequently adds more images to the list using `swayimg.imagelist.add()`, the internal `ImageList` grows correctly, but the **Viewer's UI state remains stale**. The text overlay continues to display `1/1` because the Viewer has not been notified to re-index its current position within the now-larger list.

### The Solution
This PR ensures that when a `FileCreate` event is processed (which is triggered by Lua's `add` function), the Viewer performs a "re-sync". 

By calling `open_file` with the currently displayed image entry, we force the Viewer to:
1. Re-scan the updated `ImageList`.
2. Locate the current image's new index.
3. Updat

https://github.com/user-attachments/assets/161b9b02-d63a-4640-85fd-50dbc3de41a6

