### PR TITLE
fix: filter non-image files from list using magic bytes header check

### DIFF
--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -5,6 +5,7 @@
 #include "imagelist.hpp"
 
 #include "fsmonitor.hpp"
+#include "imageloader.hpp"
 #include "log.hpp"
 
 #include <algorithm>
@@ -496,6 +497,12 @@ ImageEntryPtr ImageList::add_file(const std::filesystem::path& path,
 
     if (!std::filesystem::is_regular_file(path)) {
         Log::warning("File {} is not a regular, skipped", path.string());
+        return nullptr;
+    }
+
+    if (!ImageLoader::check_header(path)) {
+        Log::verbose("File {} is not a supported image, skipped",
+                     path.string());
         return nullptr;
     }
 

--- a/src/imageloader.cpp
+++ b/src/imageloader.cpp
@@ -13,6 +13,7 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstring>
 
 #ifdef HAVE_LIBEXIV2
 #include <exiv2/exiv2.hpp>
@@ -259,6 +260,132 @@ ImagePtr ImageLoader::load(const ImageEntryPtr& entry)
 
     Log::verbose("Unsupported image format in {}", entry->path.string());
     return nullptr;
+}
+
+bool ImageLoader::check_header(const std::filesystem::path& path)
+{
+    // DICOM has the largest signature offset (128 bytes + 4 byte signature)
+    static constexpr size_t header_size = 132;
+
+    const int fd = open(path.c_str(), O_RDONLY);
+    if (fd == -1) {
+        return false;
+    }
+
+    uint8_t header[header_size];
+    const ssize_t bytes_read = read(fd, header, header_size);
+    close(fd);
+
+    if (bytes_read < 2) {
+        return false;
+    }
+    const size_t len = static_cast<size_t>(bytes_read);
+
+    // PNG: 8-byte signature starting with 0x89 0x50 0x4e 0x47
+    if (len >= 4 && header[0] == 0x89 && header[1] == 'P' && header[2] == 'N' &&
+        header[3] == 'G') {
+        return true;
+    }
+
+    // JPEG: starts with 0xff 0xd8
+    if (len >= 2 && header[0] == 0xff && header[1] == 0xd8) {
+        return true;
+    }
+
+    // BMP: starts with "BM"
+    if (len >= 2 && header[0] == 'B' && header[1] == 'M') {
+        return true;
+    }
+
+    // GIF: starts with "GIF"
+    if (len >= 3 && header[0] == 'G' && header[1] == 'I' && header[2] == 'F') {
+        return true;
+    }
+
+    // WebP: starts with "RIFF"
+    if (len >= 4 && header[0] == 'R' && header[1] == 'I' && header[2] == 'F' &&
+        header[3] == 'F') {
+        return true;
+    }
+
+    // TIFF: little-endian (II*\0) or big-endian (MM\0*)
+    if (len >= 4 &&
+        ((header[0] == 0x49 && header[1] == 0x49 && header[2] == 0x2a &&
+          header[3] == 0x00) ||
+         (header[0] == 0x4d && header[1] == 0x4d && header[2] == 0x00 &&
+          header[3] == 0x2a))) {
+        return true;
+    }
+
+    // QOI: starts with "qoif"
+    if (len >= 4 && header[0] == 'q' && header[1] == 'o' && header[2] == 'i' &&
+        header[3] == 'f') {
+        return true;
+    }
+
+    // Farbfeld: starts with "farbfeld"
+    if (len >= 8 && std::memcmp(header, "farbfeld", 8) == 0) {
+        return true;
+    }
+
+    // EXR: starts with 0x76 0x2f 0x31 0x01
+    if (len >= 4 && header[0] == 0x76 && header[1] == 0x2f &&
+        header[2] == 0x31 && header[3] == 0x01) {
+        return true;
+    }
+
+    // PNM: starts with 'P' followed by '1'-'6'
+    if (len >= 2 && header[0] == 'P' && header[1] >= '1' && header[1] <= '6') {
+        return true;
+    }
+
+    // DICOM: "DICM" at offset 128
+    if (len >= 132 && std::memcmp(header + 128, "DICM", 4) == 0) {
+        return true;
+    }
+
+    // Sixel: starts with ESC (0x1b)
+    if (len >= 1 && header[0] == 0x1b) {
+        return true;
+    }
+
+    // SVG: search for "<svg" within the header
+    if (len >= 4) {
+        for (size_t i = 0; i + 4 <= len; ++i) {
+            if (std::memcmp(header + i, "<svg", 4) == 0) {
+                return true;
+            }
+        }
+    }
+
+    // AVIF/HEIF: "ftyp" at offset 4
+    if (len >= 8 && std::memcmp(header + 4, "ftyp", 4) == 0) {
+        return true;
+    }
+
+    // JPEG XL: starts with 0xff 0x0a (codestream) or
+    //          0x00 0x00 0x00 0x0c 0x4a 0x58 0x4c 0x20 (container)
+    if (len >= 2 && header[0] == 0xff && header[1] == 0x0a) {
+        return true;
+    }
+    if (len >= 8 && header[0] == 0x00 && header[1] == 0x00 &&
+        header[2] == 0x00 && header[3] == 0x0c && header[4] == 0x4a &&
+        header[5] == 0x58 && header[6] == 0x4c && header[7] == 0x20) {
+        return true;
+    }
+
+    // TGA: no magic bytes, check valid image type and bpp fields
+    if (len >= 18) {
+        const uint8_t image_type = header[2];
+        const uint8_t bpp = header[16];
+        if ((image_type == 1 || image_type == 2 || image_type == 3 ||
+             image_type == 9 || image_type == 10 || image_type == 11) &&
+            (bpp == 8 || bpp == 15 || bpp == 16 || bpp == 24 || bpp == 32)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 std::vector<ImageLoader::Instance>& ImageLoader::get_registry()

--- a/src/imageloader.hpp
+++ b/src/imageloader.hpp
@@ -62,6 +62,14 @@ public:
      */
     static ImagePtr load(const ImageEntryPtr& entry);
 
+    /**
+     * Quick check if file has a supported image format header.
+     * Reads only the first few bytes to check magic signatures.
+     * @param path path to the file
+     * @return true if file header matches a known image format
+     */
+    static bool check_header(const std::filesystem::path& path);
+
 private:
     /**
      * Get array with loaders.


### PR DESCRIPTION
From issue #420

Add a function that detects the first bytes of files supported by swayimg; now it should no longer show images in `list.total` index that do not exist or are not