### PR TITLE
gallery: customizable rows and columns

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -166,7 +166,9 @@ or in the file `/usr/share/swayimg/example.lua` after installing the program.
   * [swayimg.gallery.set_aspect](#swayimggalleryset_aspect): Set thumbnail aspect ratio
   * [swayimg.gallery.get_thumb_size](#swayimggalleryget_thumb_size): Get thumbnail size
   * [swayimg.gallery.set_thumb_size](#swayimggalleryset_thumb_size): Set thumbnail size
+  * [swayimg.gallery.set_columns](#swayimggalleryset_columns): Set fixed number of visible columns
   * [swayimg.gallery.set_padding_size](#swayimggalleryset_padding_size): Set the padding size between thumbnails
+  * [swayimg.gallery.set_rows](#swayimggalleryset_rows): Set fixed number of visible rows
   * [swayimg.gallery.set_border_size](#swayimggalleryset_border_size): Set the border size for currently selected thumbnail
   * [swayimg.gallery.set_border_color](#swayimggalleryset_border_color): Set border color for currently selected thumbnail
   * [swayimg.gallery.set_selected_scale](#swayimggalleryset_selected_scale): Set the scale factor for currently selected thumbnail
@@ -2081,6 +2083,20 @@ Since 5.0.
 
 @_param_ `size` - Thumbnail size in pixels
 
+### swayimg.gallery.set_columns
+
+```lua
+swayimg.gallery.set_columns(count: integer)
+```
+
+Set fixed number of visible columns.
+
+Since 5.3.
+
+Set `0` to restore automatic column count.
+
+@_param_ `count` - Number of visible columns
+
 ### swayimg.gallery.set_padding_size
 
 ```lua
@@ -2092,6 +2108,20 @@ Set the padding size between thumbnails.
 Since 5.0.
 
 @_param_ `size` - Padding size in pixels
+
+### swayimg.gallery.set_rows
+
+```lua
+swayimg.gallery.set_rows(count: integer)
+```
+
+Set fixed number of visible rows.
+
+Since 5.3.
+
+Set `0` to restore automatic row count.
+
+@_param_ `count` - Number of visible rows
 
 ### swayimg.gallery.set_border_size
 
@@ -2392,4 +2422,3 @@ If the value cannot be output (for example, the specified EXIF tag is
 missing), then the entire string including the key is ignored upon printing.
 
 Example: `Path to image:\t{path}`
-

--- a/extra/example.lua
+++ b/extra/example.lua
@@ -94,6 +94,8 @@ swayimg.slideshow.set_text("topleft", { "{name}" }) -- top left text block schem
 -- Gallery mode
 swayimg.gallery.set_aspect("fill")                  -- thumbnail aspect ratio
 swayimg.gallery.set_thumb_size(200)                 -- thumbnail size in pixels
+swayimg.gallery.set_columns(0)                      -- fixed visible columns (0=auto)
+swayimg.gallery.set_rows(0)                         -- fixed visible rows (0=auto)
 swayimg.gallery.set_padding_size(5)                 -- padding between thumbnails
 swayimg.gallery.set_border_size(5)                  -- border size for selected thumbnail
 swayimg.gallery.set_border_color(0xffaaaaaa)        -- border color for selected thumbnail

--- a/extra/swayimg.lua
+++ b/extra/swayimg.lua
@@ -664,10 +664,20 @@ function swayimg.gallery.get_thumb_size() end
 ---@param size integer Thumbnail size in pixels
 function swayimg.gallery.set_thumb_size(size) end
 
+---Set fixed number of visible columns.
+---Since 5.3.
+---@param count integer Number of columns, 0 for automatic layout
+function swayimg.gallery.set_columns(count) end
+
 ---Set the padding size between thumbnails.
 ---Since 5.0.
 ---@param size integer Padding size in pixels
 function swayimg.gallery.set_padding_size(size) end
+
+---Set fixed number of visible rows.
+---Since 5.3.
+---@param count integer Number of rows, 0 for automatic layout
+function swayimg.gallery.set_rows(count) end
 
 ---Set the border size for currently selected thumbnail.
 ---Since 5.0.

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -217,9 +217,25 @@ void Gallery::set_thumb_size(const size_t size)
     }
 }
 
+void Gallery::set_columns(const size_t count)
+{
+    layout.set_columns(count);
+    if (is_active()) {
+        Application::redraw();
+    }
+}
+
 void Gallery::set_padding_size(const size_t size)
 {
     layout.set_padding(std::min(size, PADDING_SIZE_MAX));
+    if (is_active()) {
+        Application::redraw();
+    }
+}
+
+void Gallery::set_rows(const size_t count)
+{
+    layout.set_rows(count);
     if (is_active()) {
         Application::redraw();
     }
@@ -390,18 +406,19 @@ void Gallery::draw(const Layout::Thumbnail& tlay, Pixmap& wnd)
 
     const bool selected = (tlay.img == layout.get_selected());
     const Size wnd_size = wnd;
-    const size_t tile_size = layout.get_thumb_size();
+    const size_t tile_width = layout.get_thumb_width();
+    const size_t tile_height = layout.get_thumb_height();
     const Pixmap* pm = get_thumbnail(tlay.img);
 
     // calculate tile position/size
     Rectangle tile {
-        tlay.pos, { tile_size, tile_size }
+        tlay.pos, { tile_width, tile_height }
     };
     if (selected) {
         tile.width *= selected_scale;
         tile.height *= selected_scale;
-        tile.x -= tile.width / 2 - tile_size / 2;
-        tile.y -= tile.height / 2 - tile_size / 2;
+        tile.x -= tile.width / 2 - tile_width / 2;
+        tile.y -= tile.height / 2 - tile_height / 2;
 
         // prevent going beyond the window
         if (tile.x + tile.width + border_size > wnd_size.width) {
@@ -569,7 +586,8 @@ void Gallery::load_thumbnail(const ImageEntryPtr& entry)
         queue.erase(entry);
     }
 
-    const size_t thumb_size = layout.get_thumb_size();
+    const size_t thumb_size =
+        std::max(layout.get_thumb_width(), layout.get_thumb_height());
 
     ThumbEntry thumb;
     thumb.entry = entry;

--- a/src/gallery.hpp
+++ b/src/gallery.hpp
@@ -59,10 +59,22 @@ public:
     void set_thumb_size(const size_t size);
 
     /**
+     * Set fixed number of visible columns.
+     * @param count number of columns, 0 for automatic layout
+     */
+    void set_columns(const size_t count);
+
+    /**
      * Set padding size.
      * @param size new padding size in pixels
      */
     void set_padding_size(const size_t size);
+
+    /**
+     * Set fixed number of visible rows.
+     * @param count number of rows, 0 for automatic layout
+     */
+    void set_rows(const size_t count);
 
     /**
      * Set border size for selected thumbnail.

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -23,10 +23,38 @@ void Layout::update()
     }
     assert(*sel_entry);
 
-    columns = std::max(static_cast<size_t>(1),
-                       window.width / (thumb_size + thumb_padding));
-    rows = std::max(static_cast<size_t>(1),
-                    window.height / (thumb_size + thumb_padding));
+    current_thumb_size = thumb_size;
+    current_thumb_width = thumb_size;
+    current_thumb_height = thumb_size;
+    if (fixed_columns || fixed_rows) {
+        if (fixed_columns) {
+            const size_t fitted = window.width / fixed_columns;
+            current_thumb_width = fitted > thumb_padding ? fitted - thumb_padding
+                                                         : 1;
+        }
+        if (fixed_rows) {
+            const size_t fitted = window.height / fixed_rows;
+            current_thumb_height =
+                fitted > thumb_padding ? fitted - thumb_padding : 1;
+        }
+        if (!fixed_columns) {
+            current_thumb_width = thumb_size;
+        }
+        if (!fixed_rows) {
+            current_thumb_height = thumb_size;
+        }
+        current_thumb_size =
+            std::max(current_thumb_width, current_thumb_height);
+    }
+
+    columns = fixed_columns
+        ? fixed_columns
+        : std::max(static_cast<size_t>(1),
+                   window.width / (current_thumb_width + thumb_padding));
+    rows = fixed_rows
+        ? fixed_rows
+        : std::max(static_cast<size_t>(1),
+                   window.height / (current_thumb_height + thumb_padding));
 
     // set preliminary position for the currently selected image
     ssize_t distance = il.distance(first_entry, sel_entry);
@@ -71,9 +99,11 @@ void Layout::update()
     const size_t used_cols = std::min(columns, total_visible);
     const size_t used_rows = (total_visible + columns - 1) / columns;
     const size_t mid_x =
-        std::min(window.width, used_cols * (thumb_size + thumb_padding));
+        std::min(window.width,
+                 used_cols * (current_thumb_width + thumb_padding));
     const size_t mid_y =
-        std::min(window.height, used_rows * (thumb_size + thumb_padding));
+        std::min(window.height,
+                 used_rows * (current_thumb_height + thumb_padding));
     const size_t offset_x = (window.width - mid_x) / 2;
     const size_t offset_y = (window.height - mid_y) / 2;
 
@@ -84,9 +114,9 @@ void Layout::update()
         Thumbnail thumb;
         thumb.col = i % columns;
         thumb.row = i / columns;
-        thumb.pos.x = offset_x + thumb.col * thumb_size;
+        thumb.pos.x = offset_x + thumb.col * current_thumb_width;
         thumb.pos.x += thumb_padding * (thumb.col + 1);
-        thumb.pos.y = offset_y + thumb.row * thumb_size;
+        thumb.pos.y = offset_y + thumb.row * current_thumb_height;
         thumb.pos.y += thumb_padding * (thumb.row + 1);
         thumb.img = img;
         scheme.emplace_back(thumb);
@@ -108,9 +138,21 @@ void Layout::set_thumb_size(const size_t size)
     update();
 }
 
+void Layout::set_columns(const size_t count)
+{
+    fixed_columns = count;
+    update();
+}
+
 void Layout::set_padding(const size_t padding)
 {
     thumb_padding = padding;
+    update();
+}
+
+void Layout::set_rows(const size_t count)
+{
+    fixed_rows = count;
     update();
 }
 
@@ -215,9 +257,9 @@ const Layout::Thumbnail* Layout::at(const Point& pos) const
 {
     for (const auto& it : scheme) {
         if (pos.x >= it.pos.x &&
-            pos.x < it.pos.x + static_cast<ssize_t>(thumb_size) &&
+            pos.x < it.pos.x + static_cast<ssize_t>(current_thumb_width) &&
             pos.y >= it.pos.y &&
-            pos.y < it.pos.y + static_cast<ssize_t>(thumb_size)) {
+            pos.y < it.pos.y + static_cast<ssize_t>(current_thumb_height)) {
             return &it;
         }
     }

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -46,16 +46,40 @@ public:
     void set_thumb_size(const size_t size);
 
     /**
-     * Get thumbnail size.
-     * @return thumbnail size in pixels
+     * Set fixed number of columns in the visible grid.
+     * @param count number of columns, 0 to use automatic layout
      */
-    inline size_t get_thumb_size() const { return thumb_size; }
+    void set_columns(const size_t count);
+
+    /**
+     * Get thumbnail size.
+     * @return current thumbnail size in pixels
+     */
+    inline size_t get_thumb_size() const { return current_thumb_size; }
+
+    /**
+     * Get current thumbnail width.
+     * @return thumbnail width in pixels
+     */
+    inline size_t get_thumb_width() const { return current_thumb_width; }
+
+    /**
+     * Get current thumbnail height.
+     * @return thumbnail height in pixels
+     */
+    inline size_t get_thumb_height() const { return current_thumb_height; }
 
     /**
      * Set padding size.
      * @param padding new padding size in pixels
      */
     void set_padding(const size_t padding);
+
+    /**
+     * Set fixed number of rows in the visible grid.
+     * @param count number of rows, 0 to use automatic layout
+     */
+    void set_rows(const size_t count);
 
     /**
      * Get number of columns in layout scheme.
@@ -109,9 +133,14 @@ public:
     [[nodiscard]] const std::vector<Thumbnail>& get_scheme() const;
 
 private:
-    size_t thumb_size = 200;       ///< Size of thumbnail in pixels
-    size_t thumb_padding = 5;      ///< Padding between thumbnails in pixels
-    std::vector<Thumbnail> scheme; ///< Layout scheme of visible thumbnails
+    size_t thumb_size = 200;           ///< Size of thumbnail in pixels
+    size_t current_thumb_size = 200;   ///< Effective thumbnail size in pixels
+    size_t current_thumb_width = 200;  ///< Effective thumbnail width in pixels
+    size_t current_thumb_height = 200; ///< Effective thumbnail height in pixels
+    size_t thumb_padding = 5;          ///< Padding between thumbnails in pixels
+    size_t fixed_columns = 0;          ///< Fixed number of columns, 0 for auto
+    size_t fixed_rows = 0;             ///< Fixed number of rows, 0 for auto
+    std::vector<Thumbnail> scheme;     ///< Layout scheme of visible thumbnails
 
     Size window;          ///< Layout size (output window)
     size_t columns, rows; ///< Size of the layout in thumbnails

--- a/src/luaengine.cpp
+++ b/src/luaengine.cpp
@@ -995,9 +995,17 @@ void LuaEngine::bind_gallery_api()
                      [](const size_t size) {
                          Gallery::self().set_thumb_size(size);
                      })
+        .addFunction("set_columns",
+                     [](const size_t count) {
+                         Gallery::self().set_columns(count);
+                     })
         .addFunction("set_padding_size",
                      [](const size_t size) {
                          Gallery::self().set_padding_size(size);
+                     })
+        .addFunction("set_rows",
+                     [](const size_t count) {
+                         Gallery::self().set_rows(count);
                      })
         .addFunction("set_border_size",
                      [](const size_t size) {


### PR DESCRIPTION
Add Lua API to configure gallery columns and rows explicitly.

When fixed dimensions are set, calculate thumbnail cell width and height from the available window space instead of forcing square auto-filled tiles. This allows wide contact-sheet style layouts while keeping the previous automatic square grid behavior when rows and columns are set to 0.