### PR TITLE
gallery: cache performance

### DIFF
--- a/src/compositor.cpp
+++ b/src/compositor.cpp
@@ -355,7 +355,7 @@ public:
     static Rectangle get_focus()
     {
         Rectangle wnd;
-        int monitor_id;
+        int monitor_id = 0;
 
         // get clients list
         const json clients = HyprlandIpc::request("j/clients");

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -346,20 +346,19 @@ void Gallery::window_redraw(Pixmap& wnd)
 
     const ImageEntryPtr current = layout.get_selected();
 
+    const auto& scheme = layout.get_scheme();
+    size_t selected_scheme_idx = 0;
+    size_t i = 0;
     // draw all exclude the currently selected
-    for (const auto& it : layout.get_scheme()) {
-        if (it.img != current) {
-            draw(it, wnd);
-        }
-    }
-
-    // draw only currently selected
-    for (const auto& it : layout.get_scheme()) {
+    for (const auto& it : scheme) {
         if (it.img == current) {
+            selected_scheme_idx = i;
+        } else {
             draw(it, wnd);
-            break;
+            i++;
         }
     }
+    draw(scheme[selected_scheme_idx], wnd);
 
     load_thumbnails();
     clear_invisible_thumbnails();

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -362,7 +362,7 @@ void Gallery::window_redraw(Pixmap& wnd)
     }
 
     load_thumbnails();
-    clear_thumbnails();
+    clear_invisible_thumbnails();
 }
 
 void Gallery::handle_mmove(const InputMouse&, const Point& pos, const Point&)
@@ -383,13 +383,7 @@ void Gallery::handle_imagelist(const ImageListEvent event,
     if (event == ImageListEvent::Modify || event == ImageListEvent::Remove) {
         // remove entry from cache
         const std::scoped_lock lock(mutex);
-        auto it = std::find_if(cache.begin(), cache.end(),
-                               [&entry](const ThumbEntry& thumb) {
-                                   return entry == thumb.entry;
-                               });
-        if (it != cache.end()) {
-            cache.erase(it);
-        }
+        cache.erase(entry);
     }
 
     if (event == ImageListEvent::Remove && entry == layout.get_selected()) {
@@ -552,7 +546,7 @@ void Gallery::load_thumbnails()
     }
 }
 
-void Gallery::clear_thumbnails()
+void Gallery::clear_invisible_thumbnails()
 {
     const std::scoped_lock lock(mutex);
 
@@ -565,20 +559,19 @@ void Gallery::clear_thumbnails()
             visible_first > cache_size / 2 ? visible_first - cache_size / 2 : 1;
         const size_t store_max = visible_last + cache_size - cache_size / 2;
 
-        std::erase_if(cache, [store_min, store_max](const ThumbEntry& thumb) {
-            return thumb.entry->index < store_min ||
-                thumb.entry->index > store_max;
-        });
+        std::erase_if(cache,
+                      [store_min, store_max](
+                          const std::pair<ImageEntryPtr, Pixmap>& key_value) {
+                          return key_value.first->index < store_min ||
+                              key_value.first->index > store_max;
+                      });
     }
 }
 
 const Pixmap* Gallery::get_thumbnail(const ImageEntryPtr& entry)
 {
-    const auto it = std::find_if(cache.begin(), cache.end(),
-                                 [&entry](const ThumbEntry& th) {
-                                     return entry == th.entry;
-                                 });
-    return it == cache.end() ? nullptr : &it->pm;
+    const auto it = cache.find(entry);
+    return it == cache.end() ? nullptr : &it->second;
 }
 
 void Gallery::load_thumbnail(const ImageEntryPtr& entry)
@@ -591,28 +584,26 @@ void Gallery::load_thumbnail(const ImageEntryPtr& entry)
 
     const size_t thumb_size = layout.get_thumb_size();
 
-    ThumbEntry thumb;
-    thumb.entry = entry;
+    Pixmap pm;
 
     if (pstore_enable) {
-        thumb.pm = pstore_load(entry);
+        pm = pstore_load(entry);
     }
 
-    if (!thumb.pm) {
-        thumb.pm = FormatFactory::self().preview(entry, thumb_size,
-                                                 aspect == Aspect::Fill);
-        if (!thumb.pm) {
+    if (!pm) {
+        pm = FormatFactory::self().preview(entry, thumb_size,
+                                           aspect == Aspect::Fill);
+        if (!pm) {
             Application::self().add_event(AppEvent::FileRemove { entry->path });
         } else if (pstore_enable) {
-            pstore_save(entry, thumb.pm);
+            pstore_save(entry, pm);
         }
     }
 
     const std::scoped_lock lock(mutex);
 
-    if (thumb.pm) {
-        thumb.entry = entry;
-        cache.emplace_back(thumb);
+    if (pm) {
+        cache.insert_or_assign(entry, pm);
     }
     active.erase(entry);
 

--- a/src/gallery.hpp
+++ b/src/gallery.hpp
@@ -9,9 +9,9 @@
 #include "layout.hpp"
 #include "threadpool.hpp"
 
-#include <deque>
 #include <mutex>
 #include <set>
+#include <unordered_map>
 
 class Gallery : public AppMode {
 public:
@@ -168,9 +168,9 @@ private:
     void load_thumbnails();
 
     /**
-     * Remove unused thumbnails from the cache.
+     * Remove invisible thumbnails from the cache.
      */
-    void clear_thumbnails();
+    void clear_invisible_thumbnails();
 
     /**
      * Get thumbnail pixmap for specified image.
@@ -217,12 +217,11 @@ private:
     bool pstore_enable; ///< Use persistent storage for thumbnails
     std::filesystem::path pstore_path; ///< Persistent storage path
 
-    /** Thumbnail entry. */
-    struct ThumbEntry {
-        ImageEntryPtr entry;
-        Pixmap pm;
-    };
-    std::deque<ThumbEntry> cache;   ///< Thumbnails cache
+    /**
+     * Thumbnails cache.
+     * ImageEntry caching allows determining the current index of the thumbnail.
+     */
+    std::unordered_map<ImageEntryPtr, Pixmap> cache;
     std::set<ImageEntryPtr> queue;  ///< Loading queue
     std::set<ImageEntryPtr> active; ///< Currently loading
 


### PR DESCRIPTION
1st change in a series of changes making large imagelist changes more performant

relates to #481

I snuck in also the `clear_cache` api method that now allows the user to actually reload the thumbnails. This is useful in cases like large thumbnail size increase where the quality of the already generated thumbnails in memory would otherwise compromise the UX.