### PR TITLE
List optimizations

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -162,7 +162,7 @@ ImageEntryPtr Application::add_image_entry(const std::filesystem::path& path)
     // update image list text info
     Text& text = Text::self();
     text.set_field(Text::FIELD_LIST_INDEX,
-                   std::to_string(current_mode()->current_entry()->index));
+                   std::to_string(current_mode()->current_entry()->index + 1));
     text.set_field(Text::FIELD_LIST_TOTAL, std::to_string(il.size()));
     text.update();
 
@@ -185,7 +185,7 @@ void Application::remove_image_entry(const std::filesystem::path& path)
     // update image list text info
     Text& text = Text::self();
     text.set_field(Text::FIELD_LIST_INDEX,
-                   std::to_string(current_mode()->current_entry()->index));
+                   std::to_string(current_mode()->current_entry()->index + 1));
     text.set_field(Text::FIELD_LIST_TOTAL, std::to_string(il.size()));
     text.update();
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -151,7 +151,7 @@ ImageEntryPtr Application::add_image_entry(const std::filesystem::path& path)
 {
     ImageList& il = ImageList::self();
 
-    const std::vector<ImageEntryPtr> entries = il.add(path);
+    const std::list<ImageEntryPtr> entries = il.add(path);
     if (entries.empty()) {
         return nullptr;
     }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -22,6 +22,12 @@ ImageEntry::operator bool() const
     return index != INVALID_INDEX;
 }
 
+bool ImageEntry::is_special(const std::string& path)
+{
+    return path.starts_with(ImageEntry::SRC_STDIN) ||
+        path.starts_with(ImageEntry::SRC_EXEC);
+}
+
 void Image::draw(const size_t frame, Pixmap& target, const double scale,
                  const ssize_t x, const ssize_t y)
 {

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -35,6 +35,13 @@ struct ImageEntry {
     static constexpr const char* SRC_STDIN = "stdin://";
     // Special prefix used to load images from external command output
     static constexpr const char* SRC_EXEC = "exec://";
+
+    /**
+     * Check if path is a special source.
+     * @param path path to check for special source format
+     * @return true if path starts with stdin:// or exec://
+     */
+    static bool is_special(const std::string& path);
 };
 
 using ImageEntryPtr = std::shared_ptr<ImageEntry>;

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -17,7 +17,7 @@ struct ImageEntry {
     std::filesystem::path path; ///< Path to the image file
     std::time_t mtime;          ///< File modification time
     size_t size;                ///< Size of the image file
-    size_t index;               ///< Image index in image list
+    size_t index;               ///< Image index in image list (0-based)
     bool mark;                  ///< Marked image flag
 
     /**

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -158,7 +158,7 @@ ImageEntryPtr ImageList::load(const std::vector<std::filesystem::path>& sources)
     // files to the list
     adjacent = false;
 
-    // get first entry
+    // get first entry of the source list (not of the contents of the sources)
     ImageEntryPtr first = nullptr;
     for (auto& path : sources) {
         first = find(path);
@@ -179,7 +179,7 @@ ImageEntryPtr ImageList::load(const std::vector<std::filesystem::path>& sources)
             }
         }
     }
-    return first ? first : *entries.begin();
+    return first ? first : entries.front();
 }
 
 ImageEntryPtr ImageList::load(const std::filesystem::path& list_file)
@@ -203,13 +203,10 @@ ImageEntryPtr ImageList::load(const std::filesystem::path& list_file)
     return load(sources);
 }
 
-std::vector<ImageEntryPtr> ImageList::add(const std::filesystem::path& path)
+std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path)
 {
     const std::unique_lock lock(mutex);
-
-    std::vector<ImageEntryPtr> entries = add(path, true);
-
-    return entries;
+    return add(path, true);
 }
 
 ImageEntryPtr ImageList::remove(const ImageEntryPtr& entry, bool forward)
@@ -392,11 +389,9 @@ ssize_t ImageList::distance(const ImageEntryPtr& from, const ImageEntryPtr& to)
     return static_cast<ssize_t>(to->index) - static_cast<ssize_t>(from->index);
 }
 
-std::vector<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
-                                          const bool ordered)
+std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
+                                        const bool ordered)
 {
-    std::vector<ImageEntryPtr> entries;
-
     if (path.string().starts_with(ImageEntry::SRC_STDIN) ||
         path.string().starts_with(ImageEntry::SRC_EXEC)) {
         ImageEntryPtr entry = std::make_shared<ImageEntry>();
@@ -405,39 +400,47 @@ std::vector<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
         entry->size = 0;
         entry->index = 0;
         if (add_entry(entry, ordered)) {
-            entries.push_back(entry);
+            return { entry };
         }
-    } else {
-        std::filesystem::path abs_path;
-        try {
-            abs_path = std::filesystem::absolute(path).lexically_normal();
-        } catch (...) {
-            Log::warning("Invalid path {}, skipped", path.string());
-            return {};
-        }
-        if (!std::filesystem::exists(path)) {
-            Log::warning("File {} not found, skipped", path.string());
-            return {};
-        }
+        return {};
+    }
 
-        if (std::filesystem::is_directory(path)) {
-            entries = add_dir(abs_path, ordered);
-        } else if (adjacent) {
-            const std::vector<ImageEntryPtr> edir =
-                add_dir(abs_path.parent_path(), ordered);
-            entries.insert(entries.end(), edir.begin(), edir.end());
-        } else {
-            entries.push_back(add_file(abs_path, ordered));
+    std::filesystem::path abs_path;
+    try {
+        abs_path = std::filesystem::absolute(path).lexically_normal();
+    } catch (...) {
+        Log::warning("Invalid path {}, skipped", path.string());
+        return {};
+    }
+    if (!std::filesystem::exists(path)) {
+        Log::warning("File {} not found, skipped", path.string());
+        return {};
+    }
+
+    if (std::filesystem::is_directory(path)) {
+        auto ret = add_dir(abs_path);
+        if (!ret.empty() && ordered) {
+            sort(false);
+        }
+        return ret;
+    } else if (adjacent) {
+        auto ret = add_dir(abs_path.parent_path());
+        if (!ret.empty() && ordered) {
+            sort(false);
+        }
+        return ret;
+    } else {
+        if (const ImageEntryPtr& entry = add_file(abs_path, ordered)) {
+            return { entry };
         }
     }
 
-    return entries;
+    return {};
 }
 
-std::vector<ImageEntryPtr> ImageList::add_dir(const std::filesystem::path& path,
-                                              const bool ordered)
+std::list<ImageEntryPtr> ImageList::add_dir(const std::filesystem::path& path)
 {
-    std::vector<ImageEntryPtr> entries;
+    std::list<ImageEntryPtr> added;
 
     if (fsmon) {
         FsMonitor::self().add(path);
@@ -448,24 +451,19 @@ std::vector<ImageEntryPtr> ImageList::add_dir(const std::filesystem::path& path,
             const std::filesystem::path& sub_path = it.path();
             if (std::filesystem::is_directory(sub_path)) {
                 if (recursive) {
-                    std::vector<ImageEntryPtr> added = add_dir(sub_path, false);
-                    entries.insert(entries.end(), added.begin(), added.end());
+                    added.splice(added.end(), add_dir(sub_path));
                 }
             } else {
                 const ImageEntryPtr entry = add_file(sub_path, false);
                 if (entry) {
-                    entries.push_back(entry);
+                    added.emplace_back(entry);
                 }
             }
         }
     } catch (const std::filesystem::filesystem_error&) {
     }
 
-    if (!entries.empty() && ordered) {
-        sort(false);
-    }
-
-    return entries;
+    return added;
 }
 
 ImageEntryPtr ImageList::add_file(const std::filesystem::path& path,
@@ -533,7 +531,7 @@ bool ImageList::add_entry(ImageEntryPtr& entry, const bool ordered)
     return true;
 }
 
-void ImageList::sort(bool locked)
+void ImageList::sort(const bool locked)
 {
     if (locked) {
         mutex.lock();

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -256,8 +256,7 @@ ImageEntryPtr ImageList::find(const std::filesystem::path& path)
     if (search.empty()) {
         return nullptr;
     }
-    if (!search.starts_with(ImageEntry::SRC_STDIN) &&
-        !search.starts_with(ImageEntry::SRC_EXEC)) {
+    if (!ImageEntry::is_special(search)) {
         try {
             search = std::filesystem::absolute(path).lexically_normal();
         } catch (...) {
@@ -392,14 +391,8 @@ ssize_t ImageList::distance(const ImageEntryPtr& from, const ImageEntryPtr& to)
 std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
                                         const bool ordered)
 {
-    if (path.string().starts_with(ImageEntry::SRC_STDIN) ||
-        path.string().starts_with(ImageEntry::SRC_EXEC)) {
-        ImageEntryPtr entry = std::make_shared<ImageEntry>();
-        entry->path = path;
-        entry->mtime = 0;
-        entry->size = 0;
-        entry->index = 0;
-        if (add_entry(entry, ordered)) {
+    if (ImageEntry::is_special(path)) {
+        if (const ImageEntryPtr& entry = add_special_source(path, ordered)) {
             return { entry };
         }
         return {};
@@ -433,9 +426,8 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
         if (const ImageEntryPtr& entry = add_file(abs_path, ordered)) {
             return { entry };
         }
+        return {};
     }
-
-    return {};
 }
 
 std::list<ImageEntryPtr> ImageList::add_dir(const std::filesystem::path& path)
@@ -495,6 +487,22 @@ ImageEntryPtr ImageList::add_file(const std::filesystem::path& path,
         FsMonitor::self().add(path);
     }
     return entry;
+}
+
+ImageEntryPtr ImageList::add_special_source(const std::filesystem::path& path,
+                                            const bool ordered)
+{
+    assert(is_special_source(path));
+
+    ImageEntryPtr entry = std::make_shared<ImageEntry>();
+    entry->path = path;
+    entry->mtime = 0;
+    entry->size = 0;
+    entry->index = 0;
+    if (add_entry(entry, ordered)) {
+        return entry;
+    }
+    return nullptr;
 }
 
 bool ImageList::add_entry(ImageEntryPtr& entry, const bool ordered)

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -209,7 +209,7 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path)
     return add(path, true);
 }
 
-ImageEntryPtr ImageList::remove(const ImageEntryPtr& entry, bool forward)
+ImageEntryPtr ImageList::remove(const ImageEntryPtr& entry, const bool forward)
 {
     assert(entry);
 
@@ -505,7 +505,7 @@ ImageEntryPtr ImageList::add_special_source(const std::filesystem::path& path,
     return nullptr;
 }
 
-bool ImageList::add_entry(ImageEntryPtr& entry, const bool ordered)
+bool ImageList::add_entry(const ImageEntryPtr& entry, const bool ordered)
 {
     auto [it, inserted] = entry_map.insert({ entry->path, entry });
 
@@ -562,18 +562,17 @@ void ImageList::sort(const bool locked)
                   });
     }
 
-    reindex(0);
+    reindex();
 
     if (locked) {
         mutex.unlock();
     }
 }
 
-void ImageList::reindex(size_t index)
+void ImageList::reindex(const size_t index)
 {
-    auto end = entries.end();
-    auto it = entries.begin() + index;
-    while (it != end) {
-        (*it++)->index = index++;
+    // i-- to reindex also at the actual index
+    for (size_t i = entries.size(); i-- > index;) {
+        entries[i]->index = i;
     }
 }

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -208,9 +208,6 @@ std::vector<ImageEntryPtr> ImageList::add(const std::filesystem::path& path)
     const std::unique_lock lock(mutex);
 
     std::vector<ImageEntryPtr> entries = add(path, true);
-    if (!entries.empty()) {
-        reindex();
-    }
 
     return entries;
 }
@@ -227,9 +224,9 @@ ImageEntryPtr ImageList::remove(const ImageEntryPtr& entry, bool forward)
 
     entry_map.erase(entry->path);
     entries.erase(entries.begin() + entry->index);
-    entry->remove();
+    reindex(entry->index);
 
-    reindex();
+    entry->remove();
 
     return next;
 }
@@ -341,7 +338,6 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const Dir dir)
     }
 
     auto it = entries.begin() + index;
-    assert(it != entries.end());
 
     const std::filesystem::path from_parent = from->path.parent_path();
     if (dir == Dir::NextParent) {
@@ -529,7 +525,9 @@ bool ImageList::add_entry(ImageEntryPtr& entry, const bool ordered)
                               });
         }
 
+        entry->index = it == entries.end() ? entries.size() : (*it)->index;
         entries.insert(it, entry);
+        reindex(entry->index + 1); // reindex all entries after this one
     }
 
     return true;
@@ -558,17 +556,18 @@ void ImageList::sort(bool locked)
                   });
     }
 
-    reindex();
+    reindex(0);
 
     if (locked) {
         mutex.unlock();
     }
 }
 
-void ImageList::reindex()
+void ImageList::reindex(size_t index)
 {
-    size_t index = 0;
-    for (auto& it : entries) {
-        it->index = index++;
+    auto end = entries.end();
+    auto it = entries.begin() + index;
+    while (it != end) {
+        (*it++)->index = index++;
     }
 }

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -225,9 +225,8 @@ ImageEntryPtr ImageList::remove(const ImageEntryPtr& entry, bool forward)
 
     const std::unique_lock lock(mutex);
 
+    entry_map.erase(entry->path);
     entries.erase(entries.begin() + entry->index);
-    duplicates.erase(entry->path);
-
     entry->remove();
 
     reindex();
@@ -274,11 +273,8 @@ ImageEntryPtr ImageList::find(const std::filesystem::path& path)
 
     const std::shared_lock lock(mutex);
 
-    auto it = std::find_if(entries.begin(), entries.end(),
-                           [&search](const ImageEntryPtr& entry) {
-                               return search == entry->path;
-                           });
-    return it == entries.end() ? nullptr : *it;
+    auto it = entry_map.find(search);
+    return it == entry_map.end() ? nullptr : it->second;
 }
 
 std::vector<ImageEntry> ImageList::get_all()
@@ -509,10 +505,11 @@ ImageEntryPtr ImageList::add_file(const std::filesystem::path& path,
 
 bool ImageList::add_entry(ImageEntryPtr& entry, const bool ordered)
 {
-    if (duplicates.contains(entry->path)) {
+    auto [it, inserted] = entry_map.insert({ entry->path, entry });
+
+    if (!inserted) {
         return false; // already exists
     }
-    duplicates.insert(entry->path);
 
     if (!ordered || entries.empty() || order == Order::None) {
         entry->index = entries.size();

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -343,20 +343,19 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const Dir dir)
                 return *it;
             }
         }
-    } else if (dir == Dir::PrevParent && index > 0) {
+        return nullptr;
+    }
+    if (dir == Dir::PrevParent) {
         const auto start = entries.begin();
-        while (true) {
-            it--;
+        while (it-- != start) {
             if (from_parent != (*it)->path.parent_path()) {
                 return *it;
             }
-
-            if (it == start) {
-                break;
-            }
         }
+        return nullptr;
     }
 
+    assert(false && "unhandled iterating position");
     return nullptr;
 }
 
@@ -392,7 +391,8 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
                                         const bool ordered)
 {
     if (ImageEntry::is_special(path)) {
-        if (const ImageEntryPtr& entry = add_special_source(path, ordered)) {
+        const ImageEntryPtr entry = add_special_source(path, ordered);
+        if (entry) {
             return { entry };
         }
         return {};
@@ -405,25 +405,26 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
         Log::warning("Invalid path {}, skipped", path.string());
         return {};
     }
-    if (!std::filesystem::exists(path)) {
-        Log::warning("File {} not found, skipped", path.string());
+    if (!std::filesystem::exists(abs_path)) {
+        Log::warning("File {} not found, skipped", abs_path.string());
         return {};
     }
 
-    if (std::filesystem::is_directory(path)) {
-        auto ret = add_dir(abs_path);
-        if (!ret.empty() && ordered) {
+    if (std::filesystem::is_directory(abs_path)) {
+        std::list<ImageEntryPtr> added = add_dir(abs_path);
+        if (!added.empty() && ordered) {
             sort(false);
         }
-        return ret;
+        return added;
     } else if (adjacent) {
-        auto ret = add_dir(abs_path.parent_path());
-        if (!ret.empty() && ordered) {
+        std::list<ImageEntryPtr> added = add_dir(abs_path.parent_path());
+        if (!added.empty() && ordered) {
             sort(false);
         }
-        return ret;
+        return added;
     } else {
-        if (const ImageEntryPtr& entry = add_file(abs_path, ordered)) {
+        const ImageEntryPtr entry = add_file(abs_path, ordered);
+        if (entry) {
             return { entry };
         }
         return {};
@@ -492,7 +493,7 @@ ImageEntryPtr ImageList::add_file(const std::filesystem::path& path,
 ImageEntryPtr ImageList::add_special_source(const std::filesystem::path& path,
                                             const bool ordered)
 {
-    assert(is_special_source(path));
+    assert(ImageEntry::is_special(path));
 
     ImageEntryPtr entry = std::make_shared<ImageEntry>();
     entry->path = path;

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -151,9 +151,8 @@ ImageEntryPtr ImageList::load(const std::vector<std::filesystem::path>& sources)
     for (auto& it : sources) {
         add(it, false);
     }
+    sort(false);
     mutex.unlock();
-
-    sort(true);
 
     // disable loading of adjacent files, otherwise fs mon will add unnecessary
     // files to the list
@@ -226,7 +225,7 @@ ImageEntryPtr ImageList::remove(const ImageEntryPtr& entry, bool forward)
 
     const std::unique_lock lock(mutex);
 
-    entries.remove(entry);
+    entries.erase(entries.begin() + entry->index);
     duplicates.erase(entry->path);
 
     entry->remove();
@@ -312,16 +311,14 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const Dir dir)
 
     assert(from);
 
+    if (*from && entries.size() == 1) {
+        return nullptr;
+    }
+
     if (dir == Dir::Random) {
-        if (entries.size() <= 1) {
-            return nullptr;
-        }
         ImageEntryPtr random = from;
         while (random == from) {
-            const size_t distance = rand() % entries.size();
-            auto it = entries.begin();
-            std::advance(it, distance);
-            random = *it;
+            random = entries[rand() % entries.size()];
         }
         return random;
     }
@@ -337,36 +334,41 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const Dir dir)
         return it == entries.end() ? entries.front() : *it;
     }
 
-    auto it = std::find(entries.begin(), entries.end(), from);
+    const size_t index = from->index;
+    assert(index < entries.size());
 
     if (dir == Dir::Next) {
-        return ++it == entries.end() ? nullptr : *it;
+        return index == entries.size() - 1 ? nullptr : entries[index + 1];
     }
     if (dir == Dir::Prev) {
-        return --it == entries.end() ? nullptr : *it;
+        return index == 0 ? nullptr : entries[index - 1];
     }
 
+    auto it = entries.begin() + index;
     assert(it != entries.end());
 
     const std::filesystem::path from_parent = from->path.parent_path();
     if (dir == Dir::NextParent) {
-        while (++it != entries.end()) {
+        const auto end = entries.end();
+        while (++it != end) {
             if (from_parent != (*it)->path.parent_path()) {
                 return *it;
             }
         }
-        return nullptr;
-    }
-    if (dir == Dir::PrevParent) {
-        while (--it != entries.end()) {
+    } else if (dir == Dir::PrevParent && index > 0) {
+        const auto start = entries.begin();
+        while (true) {
+            it--;
             if (from_parent != (*it)->path.parent_path()) {
                 return *it;
             }
+
+            if (it == start) {
+                break;
+            }
         }
-        return nullptr;
     }
 
-    assert(false && "unhandled iterating position");
     return nullptr;
 }
 
@@ -376,23 +378,13 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const ssize_t distance)
 
     assert(from && *from);
 
-    auto it = std::find(entries.begin(), entries.end(), from);
-    assert(it != entries.end());
-
-    ssize_t step = distance;
-    if (step > 0) {
-        while (it != entries.end() && step) {
-            --step;
-            ++it;
-        }
-    } else if (step < 0) {
-        while (it != entries.end() && step) {
-            ++step;
-            --it;
-        }
+    const size_t index = from->index;
+    if (index + distance >= entries.size() ||
+        static_cast<ssize_t>(index) + distance < 0) {
+        return nullptr;
     }
 
-    return it == entries.end() ? nullptr : *it;
+    return entries[index + distance];
 }
 
 ssize_t ImageList::distance(const ImageEntryPtr& from, const ImageEntryPtr& to)
@@ -402,44 +394,10 @@ ssize_t ImageList::distance(const ImageEntryPtr& from, const ImageEntryPtr& to)
 
     const std::shared_lock lock(mutex);
 
-    ssize_t distance = 0;
-    bool forward = true;
+    assert(from->index < entries.size());
+    assert(to->index < entries.size());
 
-    auto it_from = entries.end();
-    auto it_to = entries.end();
-
-    auto it = entries.begin();
-    while (it != entries.end()) {
-        if (*it == from) {
-            it_from = it;
-            if (it_to == entries.end()) {
-                forward = true;
-            }
-        }
-        if (*it == to) {
-            it_to = it;
-            if (it_from == entries.end()) {
-                forward = false;
-            }
-        }
-        ++it;
-    }
-
-    assert(it_from != entries.end());
-    assert(it_to != entries.end());
-
-    it = it_from;
-    while (it != it_to) {
-        if (forward) {
-            ++distance;
-            ++it;
-        } else {
-            --distance;
-            --it;
-        }
-    }
-
-    return distance;
+    return static_cast<ssize_t>(to->index) - static_cast<ssize_t>(from->index);
 }
 
 std::vector<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
@@ -467,17 +425,17 @@ std::vector<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
         }
         if (!std::filesystem::exists(path)) {
             Log::warning("File {} not found, skipped", path.string());
+            return {};
+        }
+
+        if (std::filesystem::is_directory(path)) {
+            entries = add_dir(abs_path, ordered);
+        } else if (adjacent) {
+            const std::vector<ImageEntryPtr> edir =
+                add_dir(abs_path.parent_path(), ordered);
+            entries.insert(entries.end(), edir.begin(), edir.end());
         } else {
-            if (std::filesystem::is_directory(path)) {
-                entries = add_dir(abs_path, ordered);
-            } else {
-                entries.push_back(add_file(abs_path, ordered));
-                if (adjacent) {
-                    const std::vector<ImageEntryPtr> edir =
-                        add_dir(abs_path.parent_path(), ordered);
-                    entries.insert(entries.end(), edir.begin(), edir.end());
-                }
-            }
+            entries.push_back(add_file(abs_path, ordered));
         }
     }
 
@@ -556,25 +514,24 @@ bool ImageList::add_entry(ImageEntryPtr& entry, const bool ordered)
     }
     duplicates.insert(entry->path);
 
-    if (!ordered || order == Order::None) {
+    if (!ordered || entries.empty() || order == Order::None) {
+        entry->index = entries.size();
         entries.push_back(entry);
-    } else if (order == Order::Random) {
-        if (entries.size() <= 1) {
-            entries.push_back(entry);
-        } else {
-            const size_t distance = rand() % entries.size();
-            auto it = entries.begin();
-            std::advance(it, distance);
-            entries.insert(it, entry);
-        }
     } else {
-        // search the right place to insert new entry according to sort order
-        auto it = std::find_if(entries.begin(), entries.end(),
-                               [&entry, this](const ImageEntryPtr& it) {
-                                   const bool cmp =
-                                       compare_entries(*entry, *it, order);
-                                   return reverse ? !cmp : cmp;
-                               });
+        std::vector<ImageEntryPtr>::iterator it;
+        if (order == Order::Random) {
+            it = entries.begin() + rand() % entries.size();
+        } else {
+            // search the right place to insert new entry according to sort
+            // order
+            it = std::find_if(entries.begin(), entries.end(),
+                              [&entry, this](const ImageEntryPtr& it) {
+                                  const bool cmp =
+                                      compare_entries(*entry, *it, order);
+                                  return reverse ? !cmp : cmp;
+                              });
+        }
+
         entries.insert(it, entry);
     }
 
@@ -597,10 +554,11 @@ void ImageList::sort(bool locked)
         std::shuffle(tmp.begin(), tmp.end(), engine);
         entries.assign(tmp.begin(), tmp.end());
     } else {
-        entries.sort([this](const ImageEntryPtr& l, const ImageEntryPtr& r) {
-            const bool cmp = compare_entries(*l, *r, order);
-            return reverse ? !cmp : cmp;
-        });
+        std::sort(entries.begin(), entries.end(),
+                  [this](const ImageEntryPtr& l, const ImageEntryPtr& r) {
+                      const bool cmp = compare_entries(*l, *r, order);
+                      return reverse ? !cmp : cmp;
+                  });
     }
 
     reindex();
@@ -614,6 +572,6 @@ void ImageList::reindex()
 {
     size_t index = 0;
     for (auto& it : entries) {
-        it->index = ++index;
+        it->index = index++;
     }
 }

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -8,9 +8,7 @@
 
 #include <ctime>
 #include <filesystem>
-#include <list>
 #include <shared_mutex>
-#include <unordered_set>
 #include <vector>
 
 /** Thread-safe list of images. */
@@ -183,8 +181,8 @@ private:
     std::vector<ImageEntryPtr> entries; ///< List of image entries
     std::shared_mutex mutex;            ///< Image list mutex
 
-    /** Set of paths used for searching duplicates. */
-    std::unordered_set<std::filesystem::path> duplicates;
+    /** Map of entries by their paths for quick duplicate search. */
+    std::unordered_map<std::filesystem::path, ImageEntryPtr> entry_map;
 
     Order order = Order::Numeric; ///< Image list order
     bool reverse = false;         ///< Reverse order flag

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -8,6 +8,7 @@
 
 #include <ctime>
 #include <filesystem>
+#include <list>
 #include <shared_mutex>
 #include <vector>
 
@@ -58,9 +59,9 @@ public:
     /**
      * Add file or special source to the list.
      * @param path path to the file or special source
-     * @return array of added entries
+     * @return list of added entries
      */
-    std::vector<ImageEntryPtr> add(const std::filesystem::path& path);
+    std::list<ImageEntryPtr> add(const std::filesystem::path& path);
 
     /**
      * Remove image entry from the list.
@@ -134,20 +135,17 @@ private:
     /**
      * Add file or special source to the list.
      * @param path path to the file or special source
-     * @param ordered flag to add new entry to ordered position in the list
-     * @return array of added entries
+     * @return list of added entries
      */
-    std::vector<ImageEntryPtr> add(const std::filesystem::path& path,
-                                   const bool ordered);
+    std::list<ImageEntryPtr> add(const std::filesystem::path& path,
+                                 const bool ordered);
 
     /**
      * Add files from the directory to the list.
      * @param path path to the directory
-     * @param ordered flag to add new entry to ordered position in the list
-     * @return array with added entries
+     * @return list with added entries
      */
-    std::vector<ImageEntryPtr> add_dir(const std::filesystem::path& path,
-                                       const bool ordered);
+    std::list<ImageEntryPtr> add_dir(const std::filesystem::path& path);
 
     /**
      * Add file to the list.
@@ -157,6 +155,15 @@ private:
      */
     ImageEntryPtr add_file(const std::filesystem::path& path,
                            const bool ordered);
+
+    /**
+     * Add a special source (stdin://, exec://) to the list.
+     * @param path path representing the special source
+     * @param ordered flag to add new entry to ordered position in the list
+     * @return added entry (nullptr if already exists)
+     */
+    ImageEntryPtr add_special_source(const std::filesystem::path& path,
+                                     const bool ordered);
 
     /**
      * Add new entry to the list.
@@ -170,7 +177,7 @@ private:
      * Sort image list.
      * @param locked flag to lock the list before processing
      */
-    void sort(bool locked);
+    void sort(const bool locked);
 
     /**
      * Reindex the image list.

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -174,8 +174,9 @@ private:
 
     /**
      * Reindex the image list.
+     * @param index (0-based) to start reindexing from
      */
-    void reindex();
+    void reindex(size_t index);
 
 private:
     std::vector<ImageEntryPtr> entries; ///< List of image entries

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -69,7 +69,7 @@ public:
      * @param forward direction of nearest returned entry
      * @return valid nearest entry or nullptr if list is empty
      */
-    ImageEntryPtr remove(const ImageEntryPtr& entry, bool forward = true);
+    ImageEntryPtr remove(const ImageEntryPtr& entry, const bool forward = true);
 
     /**
      * Get number of entries in the image list.
@@ -171,7 +171,7 @@ private:
      * @param ordered flag to add new entry to ordered position in the list
      * @return false if entry already exists
      */
-    bool add_entry(ImageEntryPtr& entry, const bool ordered);
+    bool add_entry(const ImageEntryPtr& entry, const bool ordered);
 
     /**
      * Sort image list.
@@ -183,7 +183,7 @@ private:
      * Reindex the image list.
      * @param index (0-based) to start reindexing from
      */
-    void reindex(size_t index);
+    void reindex(const size_t index = 0);
 
 private:
     std::vector<ImageEntryPtr> entries; ///< List of image entries

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -180,8 +180,8 @@ private:
     void reindex();
 
 private:
-    std::list<ImageEntryPtr> entries; ///< List of image entries
-    std::shared_mutex mutex;          ///< Image list mutex
+    std::vector<ImageEntryPtr> entries; ///< List of image entries
+    std::shared_mutex mutex;            ///< Image list mutex
 
     /** Set of paths used for searching duplicates. */
     std::unordered_set<std::filesystem::path> duplicates;

--- a/src/luaengine.cpp
+++ b/src/luaengine.cpp
@@ -1167,7 +1167,7 @@ luabridge::LuaRef LuaEngine::entry_to_table(const ImageEntry& entry) const
 {
     luabridge::LuaRef table = luabridge::newTable(lua_state);
     table["path"] = entry.path.string();
-    table["index"] = entry.index;
+    table["index"] = entry.index + 1;
     table["size"] = entry.size;
     table["mtime"] = entry.mtime;
     table["mark"] = entry.mark;

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -195,7 +195,7 @@ void Text::reset(const ImageEntryPtr& entry)
     set_field(FIELD_FRAME_INDEX, {});
     set_field(FIELD_FRAME_TOTAL, {});
     set_field(FIELD_FILE_SIZE, std::to_string(entry->size));
-    set_field(FIELD_LIST_INDEX, std::to_string(entry->index));
+    set_field(FIELD_LIST_INDEX, std::to_string(entry->index + 1));
     set_field(FIELD_LIST_TOTAL, std::to_string(ImageList::self().size()));
     set_field(FIELD_SCALE, {});
 

--- a/test/imagelist_test.cpp
+++ b/test/imagelist_test.cpp
@@ -57,19 +57,19 @@ TEST(ImageListTest, LoadFile)
     entry = il.get(nullptr, ImageList::Dir::First);
     ASSERT_TRUE(entry);
     EXPECT_TRUE(*entry);
-    EXPECT_NE(entry->index, 0UL);
+    EXPECT_EQ(entry->index, 0UL);
     EXPECT_EQ(entry->path, "exec://1");
 
     entry = il.get(entry, ImageList::Dir::Next);
     ASSERT_TRUE(entry);
     EXPECT_TRUE(*entry);
-    EXPECT_NE(entry->index, 0UL);
+    EXPECT_EQ(entry->index, 1UL);
     EXPECT_EQ(entry->path, "exec://2 ");
 
     entry = il.get(entry, ImageList::Dir::Next);
     ASSERT_TRUE(entry);
     EXPECT_TRUE(*entry);
-    EXPECT_NE(entry->index, 0UL);
+    EXPECT_EQ(entry->index, 2UL);
     EXPECT_EQ(entry->path, "exec://3\t");
 }
 
@@ -129,7 +129,6 @@ TEST(ImageListTest, Unordered)
     const ImageEntryPtr entry = il.load(paths);
     ASSERT_TRUE(entry);
     EXPECT_TRUE(*entry);
-    EXPECT_NE(entry->index, 0UL);
     EXPECT_EQ(entry->path, "exec://2");
     EXPECT_ILEQ(il, paths);
 }


### PR DESCRIPTION
2nd change in a series of changes making large imagelist changes more performant

relates to https://github.com/artemsen/swayimg/issues/481

Tracking the newly added images is done via a inserter function in order to prepare for the bulk update which will be using an unordered set instead of a vector.