### PR TITLE
Add support for dragging files onto the application window.

### DIFF
--- a/extra/example.lua
+++ b/extra/example.lua
@@ -159,3 +159,10 @@ swayimg.gallery.on_key("Ctrl-p", function()
     end
   end
 end)
+
+-- open a dropped file in the viewer
+swayimg.viewer.on_file_drop(function(paths)
+  if #paths == 1 then
+    swayimg.viewer.open(paths[1])
+  end
+end)

--- a/extra/swayimg.lua
+++ b/extra/swayimg.lua
@@ -453,6 +453,11 @@ function swayimg_appmode.on_signal(signal, fn) end
 ---@param fn function Handler for notifications about changing the current image
 function swayimg_appmode.on_image_change(fn) end
 
+---Add a callback function called when files are dropped on the window.
+---Since 5.2.
+---@param fn fun(paths: string[]) Handler receiving an array of dropped file paths
+function swayimg_appmode.on_file_drop(fn) end
+
 ---Set text layer scheme.
 ---Since 5.0.
 ---@param pos block_position_t Text block position

--- a/src/appevent.hpp
+++ b/src/appevent.hpp
@@ -9,7 +9,9 @@
 
 #include <filesystem>
 #include <functional>
+#include <string>
 #include <variant>
+#include <vector>
 
 /** Application event. */
 namespace AppEvent {
@@ -73,6 +75,11 @@ struct FileRemove {
     std::filesystem::path path; ///< Path to the file
 };
 
+/** File drop event (drag-and-drop receive). */
+struct FileDrop {
+    std::vector<std::string> paths; ///< Dropped file paths
+};
+
 // clang-format off
 using Holder = std::variant<WindowClose,
                             WindowRedraw,
@@ -85,7 +92,8 @@ using Holder = std::variant<WindowClose,
                             Signal,
                             FileCreate,
                             FileModify,
-                            FileRemove>;
+                            FileRemove,
+                            FileDrop>;
 // clang-format on
 
 // event handler

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -403,6 +403,9 @@ void Application::handle_event(const AppEvent::Holder& event)
             } else if constexpr (std::is_same_v<decltype(event),
                                                 const AppEvent::FileRemove&>) {
                 handle_event(event);
+            } else if constexpr (std::is_same_v<decltype(event),
+                                                const AppEvent::FileDrop&>) {
+                handle_event(event);
             } else {
                 assert(false && "unhnadled event type");
                 handle_event(event);
@@ -511,6 +514,11 @@ void Application::handle_event(const AppEvent::FileRemove& event)
     if (!std::filesystem::is_directory(event.path)) {
         remove_image_entry(event.path);
     }
+}
+
+void Application::handle_event(const AppEvent::FileDrop& event)
+{
+    current_mode()->notify_file_drop(event.paths);
 }
 
 void Application::signal_handler(int signal)

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -144,6 +144,7 @@ private:
     void handle_event(const AppEvent::FileCreate& event);
     void handle_event(const AppEvent::FileModify& event);
     void handle_event(const AppEvent::FileRemove& event);
+    void handle_event(const AppEvent::FileDrop& event);
 
     // Signal handler, see std::signal for details
     static void signal_handler(int signal);

--- a/src/appmode.cpp
+++ b/src/appmode.cpp
@@ -73,6 +73,18 @@ void AppMode::subscribe_image_switch(const ImageSwitchNotify& cb)
     img_switch.push_back(cb);
 }
 
+void AppMode::subscribe_file_drop(const FileDropNotify& cb)
+{
+    file_drop.push_back(cb);
+}
+
+void AppMode::notify_file_drop(const std::vector<std::string>& paths)
+{
+    for (auto& cb : file_drop) {
+        cb(paths);
+    }
+}
+
 void AppMode::set_mark_color(const argb_t& color)
 {
     mark_color = color;

--- a/src/appmode.hpp
+++ b/src/appmode.hpp
@@ -26,6 +26,8 @@ public:
     using InputCallback = std::function<void()>;
     /** Notification handler that is called when the image is switched. */
     using ImageSwitchNotify = std::function<void()>;
+    /** Notification handler that is called when files are dropped. */
+    using FileDropNotify = std::function<void(const std::vector<std::string>&)>;
 
     AppMode();
 
@@ -122,6 +124,18 @@ public:
     void subscribe_image_switch(const ImageSwitchNotify& cb);
 
     /**
+     * Subscribe to the file drop event.
+     * @param cb event handler
+     */
+    void subscribe_file_drop(const FileDropNotify& cb);
+
+    /**
+     * Invoke the file drop event handlers.
+     * @param paths dropped file paths
+     */
+    void notify_file_drop(const std::vector<std::string>& paths);
+
+    /**
      * Set mark icon color.
      * @param color mark icon color
      */
@@ -179,6 +193,7 @@ protected:
 
 private:
     std::vector<ImageSwitchNotify> img_switch;        ///< Image switch handlers
+    std::vector<FileDropNotify> file_drop;            ///< File drop handlers
     std::map<InputKeyboard, InputCallback> kbindings; ///< Keyboard bindings
     std::map<InputMouse, InputCallback> mbindings;    ///< Mouse bindings
     std::map<InputSignal, InputCallback> sbindings;   ///< Signal bindings

--- a/src/luaengine.cpp
+++ b/src/luaengine.cpp
@@ -1154,6 +1154,20 @@ void LuaEngine::bind_appmode_api(const char* name)
                          });
                      })
         .addFunction(
+            "on_file_drop",
+            [this, appmode, name](const luabridge::LuaRef& cb) {
+                if (!cb.isFunction()) {
+                    raise_error("Invalid argument for {}.{}.on_file_drop: "
+                                "expected function, but got {}",
+                                NS_SWAYIMG, name, cb.tostring());
+                }
+                const luabridge::LuaRef* ref = add_ref(&cb);
+                appmode->subscribe_file_drop(
+                    [this, ref](const std::vector<std::string>& paths) {
+                        execute(ref, paths);
+                    });
+            })
+        .addFunction(
             "set_text",
             [this, appmode, name](const std::string& pos,
                                   const luabridge::LuaRef& table) {
@@ -1175,6 +1189,24 @@ void LuaEngine::execute(const luabridge::LuaRef* ref) const
     ref->push();
     // on error, debug.traceback returns the full Lua stack trace
     const int code = lua_pcall(lua_state, 0, 0, -2);
+    if (code != LUA_OK) {
+        const char* msg = lua_tostring(lua_state, -1);
+        print_error("{}", msg ? msg : "<?>");
+        lua_pop(lua_state, 1);
+    }
+}
+
+void LuaEngine::execute(const luabridge::LuaRef* ref,
+                        const std::vector<std::string>& args) const
+{
+    lua_pushcfunction(lua_state, traceback_fn);
+    ref->push();
+    const luabridge::LuaRef table = luabridge::newTable(lua_state);
+    for (size_t i = 0; i < args.size(); ++i) {
+        table[static_cast<int>(i + 1)] = args[i];
+    }
+    table.push();
+    const int code = lua_pcall(lua_state, 1, 0, -3);
     if (code != LUA_OK) {
         const char* msg = lua_tostring(lua_state, -1);
         print_error("{}", msg ? msg : "<?>");

--- a/src/luaengine.hpp
+++ b/src/luaengine.hpp
@@ -60,6 +60,14 @@ private:
     void execute(const luabridge::LuaRef* ref) const;
 
     /**
+     * Call a Lua function with a string list argument.
+     * @param ref reference to the Lua function to call
+     * @param args string list to pass as first argument (Lua table)
+     */
+    void execute(const luabridge::LuaRef* ref,
+                 const std::vector<std::string>& args) const;
+
+    /**
      * Convert image entry to Lua table.
      * @param entry image entry to convert
      * @return Lua table object

--- a/src/ui_wayland.cpp
+++ b/src/ui_wayland.cpp
@@ -164,6 +164,7 @@ public:
                 if (!ui->wl.datasrc) {
                     return;
                 }
+                ui->providing_dragged_data = true;
                 wl_data_source_add_listener(
                     ui->wl.datasrc, &WaylandHandler::datasrc_listener, ui);
                 wl_data_source_offer(ui->wl.datasrc, MIME_TEXT_PLAIN);
@@ -356,13 +357,21 @@ public:
         close(fd);
     }
 
-    static void on_data_source_cancelled(void*, struct wl_data_source*) {}
+    static void on_data_source_cancelled(void* data, struct wl_data_source*)
+    {
+        UiWayland* ui = reinterpret_cast<UiWayland*>(data);
+        ui->providing_dragged_data = false;
+    }
 
     static void on_data_source_dnd_drop_performed(void*, struct wl_data_source*)
     {
     }
 
-    static void on_data_source_dnd_finished(void*, struct wl_data_source*) {}
+    static void on_data_source_dnd_finished(void* data, struct wl_data_source*)
+    {
+        UiWayland* ui = reinterpret_cast<UiWayland*>(data);
+        ui->providing_dragged_data = false;
+    }
 
     static void on_data_source_action(void*, struct wl_data_source*, uint32_t)
     {
@@ -380,35 +389,32 @@ public:
     /***************************************************************************
      * Data device handlers
      **************************************************************************/
-    static wl_data_offer** get_datadev_offer()
-    {
-        static wl_data_offer* datadev_offer = nullptr;
-        return &datadev_offer;
-    }
-
     static void on_data_device_data_offer(void*, struct wl_data_device*,
-                                          struct wl_data_offer* offer)
+                                          struct wl_data_offer*)
     {
-        *get_datadev_offer() = offer;
     }
 
-    static void on_data_device_enter(void*, struct wl_data_device*,
+    static void on_data_device_enter(void* data, struct wl_data_device*,
                                      uint32_t serial, struct wl_surface*,
                                      wl_fixed_t, wl_fixed_t,
                                      struct wl_data_offer* offer)
     {
-        if (offer) {
+        UiWayland* ui = reinterpret_cast<UiWayland*>(data);
+        // Don't accept drops when we're providing drop data.
+        // Presumably, it's our own data, and the event loop will deadlock if we
+        // accept it.
+        if (ui->providing_dragged_data) {
+            wl_data_offer_destroy(offer);
+        } else if (offer) {
             wl_data_offer_accept(offer, serial, MIME_URI_LIST);
+            ui->wl.drop_offer = WaylandDataOffer(offer);
         }
     }
 
-    static void on_data_device_leave(void*, struct wl_data_device*)
+    static void on_data_device_leave(void* data, struct wl_data_device*)
     {
-        wl_data_offer** offer = get_datadev_offer();
-        if (*offer) {
-            wl_data_offer_destroy(*offer);
-            *offer = nullptr;
-        }
+        UiWayland* ui = reinterpret_cast<UiWayland*>(data);
+        ui->wl.drop_offer.reset();
     }
 
     static void on_data_device_motion(void*, struct wl_data_device*, uint32_t,
@@ -416,48 +422,95 @@ public:
     {
     }
 
-    static void on_data_device_drop(void* data, struct wl_data_device*)
+    /// Receive the data of a wayland data offer.
+    static std::optional<std::string> receive_data_offer(wl_display* display,
+                                                         wl_data_offer* offer,
+                                                         const char* mime_type)
     {
-        const UiWayland* ui = reinterpret_cast<UiWayland*>(data);
-        wl_data_offer** offer = get_datadev_offer();
-        if (!*offer) {
-            return;
-        }
-
+        // Create a pipe to transfer the data.
         int fds[2];
         if (pipe2(fds, O_CLOEXEC) == -1) {
             Log::warning(
                 "failed to create pipe to receive drag-and-drop data: error {}",
                 errno);
-            return;
+            return std::nullopt;
         }
 
-        wl_data_offer_receive(*offer, MIME_URI_LIST, fds[1]);
+        // Pass one end of the pipe to data offer and close our copy of it.
+        wl_data_offer_receive(offer, mime_type, fds[1]);
         close(fds[1]);
 
         // flush display so the source receives the request
-        wl_display_flush(ui->wl.display);
+        wl_display_flush(display);
 
-        // read dropped data from pipe
-        std::string data_str;
-        char buf[4096];
-        ssize_t n;
-        while ((n = read(fds[0], buf, sizeof(buf))) != 0) {
-            if (n == -1) {
-                Log::warning(
-                    "failed to read drag-and-drop data from pipe: error {}",
-                    errno);
+        auto poll_fd = pollfd {
+            .fd = fds[0],
+            .events = POLLIN,
+            .revents = 0,
+        };
+
+        // Make the output buffer.
+        std::string output;
+        std::size_t total_size = 0;
+
+        while (true) {
+            // Use poll() with a 100ms timeout to avoid blocking forever.
+            constexpr int POLL_TIMEOUT_MS = 100;
+            poll_fd.revents = 0;
+            const int ret = poll(&poll_fd, 1, POLL_TIMEOUT_MS);
+            if (ret == -1) {
+                Log::warning("failed to poll pipe to receive drag-and-drop "
+                             "data: error {}",
+                             errno);
+                close(fds[0]);
+                return std::nullopt;
+            } else if (ret == 0) {
+                Log::warning("timed-out waiting to receive drag-and-drop data");
+                close(fds[0]);
+                return std::nullopt;
             }
-            data_str.append(buf, n);
-        }
-        close(fds[0]);
 
-        wl_data_offer_destroy(*offer);
-        *offer = nullptr;
+            // Only polled one fd, so we don't need to check which one is ready.
+            // Just read from it now.
+            output.resize(total_size + 2048, 0);
+            const ssize_t n_read = read(fds[0], &output[total_size], 2048);
+            if (n_read > 0) {
+                total_size += n_read;
+            } else if (n_read == 0) {
+                break;
+            } else {
+                Log::warning("failed to read from pipe to receive "
+                             "drag-and-drop data: error {}",
+                             errno);
+                close(fds[0]);
+                return std::nullopt;
+            }
+        }
+
+        close(fds[0]);
+        output.resize(total_size);
+        return output;
+    }
+
+    static void on_data_device_drop(void* data, struct wl_data_device*)
+    {
+        UiWayland* ui = reinterpret_cast<UiWayland*>(data);
+        if (!ui->wl.drop_offer) {
+            return;
+        }
+
+        // Receive the data and destroy the offer.
+        wl_data_offer* offer = ui->wl.drop_offer->ptr;
+        auto dropped_data =
+            receive_data_offer(ui->wl.display, offer, MIME_URI_LIST);
+        ui->wl.drop_offer.reset();
+        if (!dropped_data.has_value()) {
+            return;
+        }
 
         // parse URI list (RFC 2483: lines ending with \r\n)
         std::vector<std::string> paths;
-        std::istringstream stream(data_str);
+        std::istringstream stream(std::move(dropped_data).value());
         std::string line;
         while (std::getline(stream, line)) {
             // strip trailing \r

--- a/src/ui_wayland.cpp
+++ b/src/ui_wayland.cpp
@@ -15,6 +15,7 @@
 
 #include <cstring>
 #include <format>
+#include <sstream>
 
 // supported MIME types for drag-and-drop
 static const char* MIME_URI_LIST = "text/uri-list";
@@ -391,10 +392,14 @@ public:
         *get_datadev_offer() = offer;
     }
 
-    static void on_data_device_enter(void*, struct wl_data_device*, uint32_t,
-                                     struct wl_surface*, wl_fixed_t, wl_fixed_t,
-                                     struct wl_data_offer*)
+    static void on_data_device_enter(void*, struct wl_data_device*,
+                                     uint32_t serial, struct wl_surface*,
+                                     wl_fixed_t, wl_fixed_t,
+                                     struct wl_data_offer* offer)
     {
+        if (offer) {
+            wl_data_offer_accept(offer, serial, MIME_URI_LIST);
+        }
     }
 
     static void on_data_device_leave(void*, struct wl_data_device*)
@@ -411,7 +416,85 @@ public:
     {
     }
 
-    static void on_data_device_drop(void*, struct wl_data_device*) {}
+    static void on_data_device_drop(void* data, struct wl_data_device*)
+    {
+        const UiWayland* ui = reinterpret_cast<UiWayland*>(data);
+        wl_data_offer** offer = get_datadev_offer();
+        if (!*offer) {
+            return;
+        }
+
+        int fds[2];
+        if (pipe2(fds, O_CLOEXEC) == -1) {
+            Log::warning(
+                "failed to create pipe to receive drag-and-drop data: error {}",
+                errno);
+            return;
+        }
+
+        wl_data_offer_receive(*offer, MIME_URI_LIST, fds[1]);
+        close(fds[1]);
+
+        // flush display so the source receives the request
+        wl_display_flush(ui->wl.display);
+
+        // read dropped data from pipe
+        std::string data_str;
+        char buf[4096];
+        ssize_t n;
+        while ((n = read(fds[0], buf, sizeof(buf))) != 0) {
+            if (n == -1) {
+                Log::warning(
+                    "failed to read drag-and-drop data from pipe: error {}",
+                    errno);
+            }
+            data_str.append(buf, n);
+        }
+        close(fds[0]);
+
+        wl_data_offer_destroy(*offer);
+        *offer = nullptr;
+
+        // parse URI list (RFC 2483: lines ending with \r\n)
+        std::vector<std::string> paths;
+        std::istringstream stream(data_str);
+        std::string line;
+        while (std::getline(stream, line)) {
+            // strip trailing \r
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            if (line.empty() || line[0] == '#') {
+                continue; // skip empty lines and comments
+            }
+            // strip file:// prefix and decode %XX sequences
+            if (line.starts_with("file://")) {
+                line = line.substr(7);
+                std::string decoded;
+                decoded.reserve(line.size());
+                for (size_t i = 0; i < line.size(); ++i) {
+                    if (line[i] == '%' && i + 2 < line.size()) {
+                        const char hex[3] = { line[i + 1], line[i + 2], '\0' };
+                        char* end = nullptr;
+                        const long val = strtol(hex, &end, 16);
+                        if (end == hex + 2) {
+                            decoded += static_cast<char>(val);
+                            i += 2;
+                            continue;
+                        }
+                    }
+                    decoded += line[i];
+                }
+                line = std::move(decoded);
+            }
+            paths.push_back(std::move(line));
+        }
+
+        if (!paths.empty()) {
+            Application::self().add_event(
+                AppEvent::FileDrop { std::move(paths) });
+        }
+    }
 
     static void on_data_device_selection(void*, struct wl_data_device*,
                                          struct wl_data_offer* offer)

--- a/src/ui_wayland.hpp
+++ b/src/ui_wayland.hpp
@@ -84,6 +84,28 @@ struct WaylandDisplay : public WaylandObject<wl_display> {
         }                                                                   \
     }
 
+struct WaylandDataOffer : public WaylandObject<wl_data_offer> {
+    WaylandDataOffer(wl_data_offer* offer)
+        : WaylandObject(wl_data_offer_destroy)
+    {
+        this->ptr = offer;
+    }
+
+    WaylandDataOffer(WaylandDataOffer const&) = delete;
+
+    WaylandDataOffer(WaylandDataOffer&& other) noexcept
+        : WaylandDataOffer(other.ptr)
+    {
+        other.ptr = nullptr;
+    }
+
+    WaylandDataOffer& operator=(WaylandDataOffer&& other) noexcept
+    {
+        std::swap(ptr, other.ptr);
+        return *this;
+    }
+};
+
 /** Wayland window buffer. */
 struct WaylandBuffer {
     ~WaylandBuffer();
@@ -207,7 +229,13 @@ private:
         WLOBJ_DECLARE(zxdg_toplevel_decoration_v1) decor;
         WLOBJ_DECLARE(ext_idle_notifier_v1) idle_mgr;
         WLOBJ_DECLARE(ext_idle_notification_v1) idle;
+        std::optional<WaylandDataOffer>
+            drop_offer; ///< Data offer currently being dragged over the window.
     } wl;
+
+    ///  Flag to remember if we've started a drag-and-drop, so we don't accept
+    ///  our own offer.
+    bool providing_dragged_data = false;
 
     WaylandBuffer wnd_buffer; ///< Window buffer
 


### PR DESCRIPTION
Add a new `on_file_drop` event to `AppMode`, allowing user code to handle dropped files. The list can contain 1 or more paths (but not 0, those are filtered out).

An example is included that simply opens single files dropped on the window.

Note that the bindings can't be removed. I followed the pattern of `on_image_change`, which doesn't seem to have a mechanism to remove a callback either.

It could be argued that `bind_reset` should also clear these event handlers, but as it is, that function only clears keyboard, mouse and signal bindings.