### PR TITLE
lua: Fixed pstore_path type conversion

### DIFF
--- a/src/luaengine.cpp
+++ b/src/luaengine.cpp
@@ -1018,7 +1018,7 @@ void LuaEngine::bind_gallery_api()
                          Gallery::self().enable_pstore(enable);
                      })
         .addFunction("set_pstore_path",
-                     [](const std::filesystem::path& path) {
+                     [](const std::string& path) {
                          Gallery::self().set_pstore_path(path);
                      })
         .endNamespace()


### PR DESCRIPTION
The pstore path variable cannot be set because luabridge tries to convert lua string into path directly. It has to be `std::string` at the api definition level.