### PR TITLE
refactor: mark as const where appropriate

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -99,14 +99,14 @@ int Application::run()
     return exit_code;
 }
 
-void Application::exit(int rc)
+void Application::exit(const int rc)
 {
     stop_flag = true;
     exit_code = rc;
     exit_event.set();
 }
 
-void Application::set_mode(Mode mode)
+void Application::set_mode(const Mode mode)
 {
     if (!initialized) {
         if (!sparams.mode.has_value()) {
@@ -192,7 +192,7 @@ void Application::remove_image_entry(const std::filesystem::path& path)
     redraw();
 }
 
-void Application::add_fdpoll(int fd, const FdEventHandler& handler)
+void Application::add_fdpoll(const int fd, const FdEventHandler& handler)
 {
     fds.emplace_back(fd, handler);
 }

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -60,13 +60,13 @@ public:
      * Exit from application.
      * @param rc result code to set
      */
-    void exit(int rc);
+    void exit(const int rc);
 
     /**
      * Switch mode (viewer/slideshow/gallery).
      * @param mode mode to set
      */
-    void set_mode(Mode mode);
+    void set_mode(const Mode mode);
 
     /**
      * Switch mode (viewer/slideshow/gallery).
@@ -98,7 +98,7 @@ public:
      * @param fd file descriptor to watch
      * @param handler callback
      */
-    void add_fdpoll(int fd, const FdEventHandler& handler);
+    void add_fdpoll(const int fd, const FdEventHandler& handler);
 
     /**
      * Add application event to the queue.

--- a/src/fdevent.cpp
+++ b/src/fdevent.cpp
@@ -55,7 +55,7 @@ void FdTimer::reset(const size_t delay, const size_t interval) const
     timerfd_settime(fd, 0, &ts, nullptr);
 }
 
-size_t FdTimer::remain(int fd) const
+size_t FdTimer::remain(const int fd) const
 {
     size_t ms = 0;
     itimerspec ts;

--- a/src/fdevent.hpp
+++ b/src/fdevent.hpp
@@ -54,5 +54,5 @@ public:
      * Get the remaining time.
      * @return remaining time in milliseconds, 0 if stopped
      */
-    [[nodiscard]] size_t remain(int fd) const;
+    [[nodiscard]] size_t remain(const int fd) const;
 };

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -148,7 +148,7 @@ bool Font::load(const uint8_t* data, const size_t data_size)
     return true;
 }
 
-void Font::set_face(FT_Face face)
+void Font::set_face(const FT_Face face)
 {
     if (ft_face) {
         FT_Done_Face(ft_face);

--- a/src/font.hpp
+++ b/src/font.hpp
@@ -77,7 +77,7 @@ private:
      * Set new font face.
      * @param face font face to set
      */
-    void set_face(FT_Face face);
+    void set_face(const FT_Face face);
 
 private:
     FT_Face ft_face = nullptr; ///< Font face instance

--- a/src/formats/avif.cpp
+++ b/src/formats/avif.cpp
@@ -19,7 +19,7 @@ public:
     using AvifDecoder =
         std::unique_ptr<avifDecoder, decltype(&avifDecoderDestroy)>;
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 'f', 't', 'y', 'p' }, 4)) {
             return nullptr;

--- a/src/formats/bmp.cpp
+++ b/src/formats/bmp.cpp
@@ -14,7 +14,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 'B', 'M' })) {
             return nullptr;

--- a/src/formats/dicom.cpp
+++ b/src/formats/dicom.cpp
@@ -19,7 +19,7 @@ public:
     static constexpr const uint8_t SIG_DATA[] = { 'D', 'I', 'C', 'M' };
     static constexpr const size_t SIG_OFFSET = 128;
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, SIG_DATA, SIG_OFFSET)) {
             return nullptr;

--- a/src/formats/exr.cpp
+++ b/src/formats/exr.cpp
@@ -23,7 +23,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 0x76, 0x2f, 0x31, 0x01 })) {
             return nullptr;

--- a/src/formats/farbfeld.cpp
+++ b/src/formats/farbfeld.cpp
@@ -15,7 +15,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data,
                              { 'f', 'a', 'r', 'b', 'f', 'e', 'l', 'd' })) {

--- a/src/formats/gif.cpp
+++ b/src/formats/gif.cpp
@@ -16,7 +16,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 'G', 'I', 'F' })) {
             return nullptr;
@@ -107,7 +107,7 @@ private:
      * @param index number of the frame to load
      */
     void decode_frame(Gif& gif, std::vector<Image::Frame>& frames,
-                      const size_t index)
+                      const size_t index) const
     {
         Image::Frame& frame = frames[index];
 

--- a/src/formats/heif.cpp
+++ b/src/formats/heif.cpp
@@ -17,7 +17,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (heif_check_filetype(data.data, data.size) !=
             heif_filetype_yes_supported) {

--- a/src/formats/jp2.cpp
+++ b/src/formats/jp2.cpp
@@ -18,7 +18,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         // check signature and get codec type
         OPJ_CODEC_FORMAT codec_fmt;

--- a/src/formats/jpeg.cpp
+++ b/src/formats/jpeg.cpp
@@ -17,7 +17,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 0xff, 0xd8 })) {
             return nullptr;

--- a/src/formats/jxl.cpp
+++ b/src/formats/jxl.cpp
@@ -16,7 +16,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         // check signature
         switch (JxlSignatureCheck(data.data, data.size)) {

--- a/src/formats/png.cpp
+++ b/src/formats/png.cpp
@@ -33,7 +33,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (png_sig_cmp(data.data, 0, data.size) != 0) {
             return nullptr;

--- a/src/formats/pnm.cpp
+++ b/src/formats/pnm.cpp
@@ -15,7 +15,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         // check signature: PNM always starts with "P"
         if (data.size < 3 || data.data[0] != 'P') {

--- a/src/formats/qoi.cpp
+++ b/src/formats/qoi.cpp
@@ -16,7 +16,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 'q', 'o', 'i', 'f' })) {
             return nullptr;

--- a/src/formats/raw.cpp
+++ b/src/formats/raw.cpp
@@ -30,7 +30,7 @@ public:
         return true;
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         // open decoder
         LibRaw decoder(0);
@@ -83,8 +83,8 @@ public:
         return image;
     }
 
-    Pixmap preview(const Data& data, const size_t sz,
-                   const bool max_sz) override
+    [[nodiscard]] Pixmap preview(const Data& data, const size_t sz,
+                                 const bool max_sz) const override
     {
         if (!FormatFactory::self().embedded_thumb) {
             return ImageFormat::preview(data, sz, max_sz);

--- a/src/formats/sixel.cpp
+++ b/src/formats/sixel.cpp
@@ -16,7 +16,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         // check signature: sixel always starts with Esc code
         if (data.data[0] != 0x1b) {

--- a/src/formats/svg.cpp
+++ b/src/formats/svg.cpp
@@ -22,7 +22,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!is_svg(data)) {
             return nullptr;

--- a/src/formats/tga.cpp
+++ b/src/formats/tga.cpp
@@ -14,7 +14,7 @@ public:
     {
     }
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (data.size < sizeof(Header)) {
             return nullptr;

--- a/src/formats/tiff.cpp
+++ b/src/formats/tiff.cpp
@@ -19,7 +19,7 @@ public:
     // Size of buffer for error messages, see libtiff for details
     static constexpr size_t LIBTIFF_ERRMSG_SZ = 1024;
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 0x49, 0x49, 0x2a, 0x00 }) &&
             !check_signature(data, { 0x4d, 0x4d, 0x00, 0x2a })) {

--- a/src/formats/ttf.cpp
+++ b/src/formats/ttf.cpp
@@ -20,7 +20,7 @@ public:
     static constexpr const char* TEXT =
         "The quick brown fox jumps over the lazy dog 0123456789";
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 0x00, 0x01, 0x00, 0x00 })) {
             return nullptr;

--- a/src/formats/webp.cpp
+++ b/src/formats/webp.cpp
@@ -20,7 +20,7 @@ public:
     using WebpDecoder =
         std::unique_ptr<WebPAnimDecoder, decltype(&WebPAnimDecoderDelete)>;
 
-    ImagePtr decode(const Data& data) override
+    [[nodiscard]] ImagePtr decode(const Data& data) const override
     {
         if (!check_signature(data, { 'R', 'I', 'F', 'F' })) {
             return nullptr;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -43,7 +43,7 @@ void Image::flip_horizontal()
     }
 }
 
-void Image::rotate(size_t angle)
+void Image::rotate(const size_t angle)
 {
     for (auto& it : frames) {
         it.pm.rotate(angle);

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -68,7 +68,7 @@ public:
      * Rotate image.
      * @param angle rotation angle (only 90, 180, or 270)
      */
-    virtual void rotate(size_t angle);
+    virtual void rotate(const size_t angle);
 
 public:
     /** Image frame. */

--- a/src/imageformat.cpp
+++ b/src/imageformat.cpp
@@ -207,7 +207,7 @@ bool ImageFormat::set_params(const std::unordered_map<std::string, bool>&)
 }
 
 Pixmap ImageFormat::preview(const Data& data, const size_t sz,
-                            const bool max_sz)
+                            const bool max_sz) const
 {
     ImagePtr image = decode(data);
     if (!image) {

--- a/src/imageformat.hpp
+++ b/src/imageformat.hpp
@@ -47,7 +47,7 @@ public:
      * @param data source data to decode
      * @return image instance or nulptr on errors
      */
-    virtual ImagePtr decode(const Data& data) = 0;
+    [[nodiscard]] virtual ImagePtr decode(const Data& data) const = 0;
 
     /**
      * Encode pixel map.
@@ -63,8 +63,8 @@ public:
      * @param max_sz size type: true if sz contains max size of the thumbnail
      * @return encoded image data, empty array on errors
      */
-    virtual Pixmap preview(const Data& data, const size_t sz,
-                           const bool max_sz);
+    [[nodiscard]] virtual Pixmap preview(const Data& data, const size_t sz,
+                                         const bool max_sz) const;
 
     /**
      * Fix orientation by EXIF data.

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -43,7 +43,7 @@ static constexpr std::array mouse_buttons =
  * @param mods combined modifier flags
  * @return text representation
  */
-static std::string modifiers_to_string(keymod_t mods)
+static std::string modifiers_to_string(const keymod_t mods)
 {
     std::string name;
     for (const auto& it : modifiers_name) {
@@ -165,7 +165,7 @@ std::optional<InputMouse> InputMouse::load(const std::string& expression)
     return InputMouse { buttons, mods };
 }
 
-InputMouse::mouse_btn_t InputMouse::to_button(uint16_t code)
+InputMouse::mouse_btn_t InputMouse::to_button(const uint16_t code)
 {
     switch (code) {
         case BTN_LEFT:

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -43,7 +43,7 @@ struct InputMouse {
 
     // * The button is a button code as defined in the Linux kernel's
     // * linux/input-event-codes.h header file, e.g. BTN_LEFT.
-    static mouse_btn_t to_button(uint16_t code);
+    static mouse_btn_t to_button(const uint16_t code);
 
     /**
      * Get buttons combination description.

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -49,7 +49,7 @@ public:
      * Get thumbnail size.
      * @return thumbnail size in pixels
      */
-    inline size_t get_thumb_size() const { return thumb_size; }
+    [[nodiscard]] inline size_t get_thumb_size() const { return thumb_size; }
 
     /**
      * Set padding size.

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -72,7 +72,7 @@ public:
      * @param ... format arguments
      */
     template <typename... Args>
-    static void error(int code, const std::format_string<Args...> fmt,
+    static void error(const int code, const std::format_string<Args...> fmt,
                       Args&&... args)
     {
         std::string msg = "ERROR: " +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,6 @@
 #include <getopt.h>
 #include <unistd.h>
 
-#include <algorithm>
 #include <clocale>
 #include <cstdlib>
 #include <format>
@@ -68,7 +67,7 @@ public:
      * @param argv arguments array
      * @return index of the first non option argument
      */
-    int process(int argc, char* argv[])
+    int process(const int argc, char* argv[])
     {
         // fill options
         std::string optstring;

--- a/src/threadpool.hpp
+++ b/src/threadpool.hpp
@@ -35,7 +35,7 @@ public:
      * Get number of threads in the pool.
      * @return number of threads
      */
-    inline size_t size() const { return threads; }
+    [[nodiscard]] inline size_t size() const { return threads; }
 
     /**
      * Add task to execution queue.

--- a/src/ui.hpp
+++ b/src/ui.hpp
@@ -44,13 +44,13 @@ public:
      * Set mouse pointer shape.
      * @param shape cursor shape to set
      */
-    virtual void set_cursor(CursorShape /* shape */) {}
+    virtual void set_cursor(const CursorShape /* shape */) {}
 
     /**
      * Set surface content type.
      * @param ctype content type to set
      */
-    virtual void set_ctype(ContentType /* type */) {}
+    virtual void set_ctype(const ContentType /* type */) {}
 
     /**
      * Enable/disable full screen mode.

--- a/src/ui_drm.cpp
+++ b/src/ui_drm.cpp
@@ -188,7 +188,7 @@ void UiDrm::commit_surface()
     }
 }
 
-bool UiDrm::drm_open(const std::filesystem::path& path, bool silent)
+bool UiDrm::drm_open(const std::filesystem::path& path, const bool silent)
 {
     assert(fd == -1);
 
@@ -213,7 +213,7 @@ bool UiDrm::drm_open(const std::filesystem::path& path, bool silent)
     return fd != -1;
 }
 
-drmModeConnectorPtr UiDrm::get_connector(drmModeResPtr resources) const
+drmModeConnectorPtr UiDrm::get_connector(const drmModeResPtr resources) const
 {
     for (int i = 0; i < resources->count_connectors; ++i) {
         drmModeConnectorPtr conn =
@@ -245,8 +245,8 @@ drmModeConnectorPtr UiDrm::get_connector(drmModeResPtr resources) const
     return nullptr;
 }
 
-uint32_t UiDrm::get_crtc(drmModeResPtr resources,
-                         drmModeConnectorPtr connector) const
+uint32_t UiDrm::get_crtc(const drmModeResPtr resources,
+                         const drmModeConnectorPtr connector) const
 {
     for (int i = 0; i < connector->count_encoders; ++i) {
         drmModeEncoderPtr enc = drmModeGetEncoder(fd, connector->encoders[i]);
@@ -263,7 +263,7 @@ uint32_t UiDrm::get_crtc(drmModeResPtr resources,
     return 0;
 }
 
-drmModeModeInfoPtr UiDrm::get_mode(drmModeConnectorPtr connector) const
+drmModeModeInfoPtr UiDrm::get_mode(const drmModeConnectorPtr connector) const
 {
     if (width && height) {
         for (int i = 0; i < connector->count_modes; ++i) {

--- a/src/ui_drm.hpp
+++ b/src/ui_drm.hpp
@@ -39,14 +39,14 @@ private:
      * @param silent flag to suppress errro message
      * @return true if DRM device was opened
      */
-    bool drm_open(const std::filesystem::path& path, bool silent);
+    bool drm_open(const std::filesystem::path& path, const bool silent);
 
     /**
      * Get DRM connector.
      * @param resources DRM resources
      * @return connector instance or nullptr if not found
      */
-    drmModeConnectorPtr get_connector(drmModeResPtr resources) const;
+    drmModeConnectorPtr get_connector(const drmModeResPtr resources) const;
 
     /**
      * Get CRTC id.
@@ -54,15 +54,15 @@ private:
      * @param connector DRM connector
      * @return CRTC id or 0 if not found
      */
-    uint32_t get_crtc(drmModeResPtr resources,
-                      drmModeConnectorPtr connector) const;
+    uint32_t get_crtc(const drmModeResPtr resources,
+                      const drmModeConnectorPtr connector) const;
 
     /**
      * Get DRM mode.
      * @param connector DRM connector
      * @return mode instance
      */
-    drmModeModeInfoPtr get_mode(drmModeConnectorPtr connector) const;
+    drmModeModeInfoPtr get_mode(const drmModeConnectorPtr connector) const;
 
     // Page flip callback, see DRM API for details
     static void on_page_flipped(int, unsigned int, unsigned int, unsigned int,


### PR DESCRIPTION
I can't do anything half-way, so I made sure that the policy of marking input parameters as `const` holds everywhere, where possible and appropriate.