### PR TITLE
imagelist: Fix get() refactor

### DIFF
--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -315,7 +315,7 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const Dir dir)
             entry = entries.back();
             break;
         case Dir::Next:
-            if (entries.size() > 1 && from->index + 1 < entries.size()) {
+            if (from->index + 1 < entries.size()) {
                 entry = entries[from->index + 1];
             }
             break;
@@ -335,7 +335,7 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const Dir dir)
         } break;
         case Dir::PrevParent: {
             const std::filesystem::path from_parent = from->path.parent_path();
-            for (ssize_t i = static_cast<ssize_t>(from->index) - 1; i > 0;
+            for (ssize_t i = static_cast<ssize_t>(from->index) - 1; i >= 0;
                  --i) {
                 if (from_parent != entries[i]->path.parent_path()) {
                     entry = entries[i];


### PR DESCRIPTION
Also simplifies the `Dir::Next` check