### PR TITLE
Allow bulk imagelist updates

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -57,6 +57,7 @@ or in the file `/usr/share/swayimg/example.lua` after installing the program.
 * Image list
   * [swayimg.imagelist.size](#swayimgimagelistsize): Get number of entries in the image list
   * [swayimg.imagelist.get](#swayimgimagelistget): Get list of all entries in the image list
+  * [swayimg.imagelist.set](#swayimgimagelistset): Set list of images to given entries
   * [swayimg.imagelist.add](#swayimgimagelistadd): Add entry to the image list
   * [swayimg.imagelist.remove](#swayimgimagelistremove): Remove entry from the image list
   * [swayimg.imagelist.set_order](#swayimgimagelistset_order): Set sort order of the image list
@@ -500,6 +501,18 @@ Get list of all entries in the image list.
 Since 5.0.
 
 @_return_ - Array with all file entries
+
+### swayimg.imagelist.set
+
+```lua
+swayimg.imagelist.set(entries: string[])
+```
+
+Set list of images to given entries.
+
+Since 5.3.
+
+@_param_ `entries` - # New list of image entries (directories get ignored)
 
 ### swayimg.imagelist.add
 

--- a/extra/swayimg.lua
+++ b/extra/swayimg.lua
@@ -284,6 +284,11 @@ function swayimg.imagelist.size() end
 ---@return swayimg.entry[] # Array with all file entries
 function swayimg.imagelist.get() end
 
+---Set list of images to given sources.
+---Since 5.3.
+---@param entries string[] # New list of sources
+function swayimg.imagelist.set(entries) end
+
 ---Add entry to the image list.
 ---Since 5.0.
 ---@param path string Path to add

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -7,6 +7,7 @@
 #include "buildconf.hpp"
 #include "fsmonitor.hpp"
 #include "gallery.hpp"
+#include "image.hpp"
 #include "imagelist.hpp"
 #include "log.hpp"
 #include "luaengine.hpp"
@@ -149,15 +150,15 @@ AppMode* Application::current_mode()
 
 ImageEntryPtr Application::add_image_entry(const std::filesystem::path& path)
 {
-    const std::list<ImageEntryPtr> entries = ImageList::self().add(path);
-    if (!entries.empty()) {
-        AppMode* mode = current_mode();
-        for (auto& it : entries) {
-            mode->handle_imagelist(AppMode::ImageListEvent::Create, it);
-        }
+    AppMode::ChangeTracker tracker;
+    tracker.added.splice(tracker.added.end(), ImageList::self().add(path));
+
+    if (tracker.added.empty()) {
+        current_mode()->handle_imagelist(tracker);
         redraw();
-        return entries.front();
+        return tracker.added.front();
     }
+
     return nullptr;
 }
 
@@ -165,10 +166,13 @@ void Application::remove_image_entry(const std::filesystem::path& path)
 {
     ImageList& il = ImageList::self();
     const ImageEntryPtr entry = il.find(path);
+
     if (entry) {
         il.remove(entry);
-        AppMode* mode = current_mode();
-        mode->handle_imagelist(AppMode::ImageListEvent::Remove, entry);
+
+        AppMode::ChangeTracker tracker;
+        tracker.removed.push_back(entry);
+        current_mode()->handle_imagelist(tracker);
         redraw();
     }
 }
@@ -493,8 +497,9 @@ void Application::handle_event(const AppEvent::FileModify& event)
         ImageList& il = ImageList::self();
         const ImageEntryPtr entry = il.find(event.path);
         if (entry) {
-            current_mode()->handle_imagelist(AppMode::ImageListEvent::Modify,
-                                             entry);
+            AppMode::ChangeTracker tracker;
+            tracker.modified.push_back(entry);
+            current_mode()->handle_imagelist(tracker);
         }
     }
 }

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -177,6 +177,18 @@ void Application::remove_image_entry(const std::filesystem::path& path)
     }
 }
 
+void Application::set_image_entries(const std::vector<std::string>& sources)
+{
+    ImageList& il = ImageList::self();
+
+    AppMode::ChangeTracker tracker;
+    il.set_entries(tracker.added, tracker.removed, sources);
+    if (!tracker.added.empty() || !tracker.removed.empty()) {
+        current_mode()->handle_imagelist(tracker);
+        redraw();
+    }
+}
+
 void Application::add_fdpoll(const int fd, const FdEventHandler& handler)
 {
     fds.emplace_back(fd, handler);

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -94,6 +94,12 @@ public:
     void remove_image_entry(const std::filesystem::path& path);
 
     /**
+     * Replace all entries in the image list.
+     * @param sources list of sources to set
+     */
+    void set_image_entries(const std::vector<std::string>& sources);
+
+    /**
      * Add file descriptor to monitor.
      * @param fd file descriptor to watch
      * @param handler callback

--- a/src/appmode.cpp
+++ b/src/appmode.cpp
@@ -53,7 +53,7 @@ bool AppMode::handle_signal(const InputSignal& input)
     return false;
 }
 
-void AppMode::handle_imagelist(const ImageListEvent, const ImageEntryPtr&)
+void AppMode::handle_imagelist(const ChangeTracker&)
 {
     Text& text = Text::self();
     text.set_field(Text::FIELD_LIST_INDEX,

--- a/src/appmode.hpp
+++ b/src/appmode.hpp
@@ -15,11 +15,11 @@
 
 class AppMode {
 public:
-    /** Image list event types. */
-    enum class ImageListEvent : uint8_t {
-        Create,
-        Modify,
-        Remove,
+    /** Image list change tracking. */
+    struct ChangeTracker {
+        std::list<ImageEntryPtr> added;
+        std::list<ImageEntryPtr> removed;
+        std::list<ImageEntryPtr> modified;
     };
 
     /** Input event handler. */
@@ -103,11 +103,9 @@ public:
 
     /**
      * Handle image list changes.
-     * @param event event type
-     * @param entry updated image entry
+     * @param tracker object with info about what has changed
      */
-    virtual void handle_imagelist(const ImageListEvent event,
-                                  const ImageEntryPtr& entry);
+    virtual void handle_imagelist(const ChangeTracker& tracker);
 
     /**
      * Check if current mode is active.

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -10,7 +10,6 @@
 #include "log.hpp"
 #include "render.hpp"
 #include "resources.hpp"
-#include "text.hpp"
 
 #include <sys/stat.h>
 
@@ -376,25 +375,41 @@ void Gallery::handle_pinch(const double scale_delta)
     set_thumb_size(get_thumb_size() + scale_delta * pinch_factor);
 }
 
-void Gallery::handle_imagelist(const ImageListEvent event,
-                               const ImageEntryPtr& entry)
+void Gallery::handle_imagelist(const AppMode::ChangeTracker& tracker)
 {
-    AppMode::handle_imagelist(event, entry);
+    AppMode::handle_imagelist(tracker);
 
-    if (event == ImageListEvent::Modify || event == ImageListEvent::Remove) {
-        // remove entry from cache
-        const std::scoped_lock lock(mutex);
-        cache.erase(entry);
-    }
+    // clear cache of invalidated entries, update selected if it was cleared
+    if (!tracker.removed.empty()) {
+        const auto current_entry = layout.get_selected();
+        bool has_selected = false;
+        {
+            const std::scoped_lock lock(mutex);
 
-    if (event == ImageListEvent::Remove && entry == layout.get_selected()) {
-        if (!layout.select(Layout::Right) && !layout.select(Layout::Left)) {
+            for (const auto& entry : tracker.removed) {
+                if (entry == current_entry) {
+                    has_selected = true;
+                }
+                cache.erase(entry);
+            }
+        }
+
+        if (has_selected && !layout.select(Layout::Right) &&
+            !layout.select(Layout::Left)) {
             Log::info("No more images to view, exit");
             Application::self().exit(0);
             return;
         }
-        switch_current();
     }
+
+    if (!tracker.modified.empty()) {
+        const std::scoped_lock lock(mutex);
+
+        for (const auto& entry : tracker.modified) {
+            cache.erase(entry);
+        }
+    }
+
     layout.update();
     Application::redraw();
 }

--- a/src/gallery.hpp
+++ b/src/gallery.hpp
@@ -151,8 +151,7 @@ public:
     void handle_mmove(const InputMouse& input, const Point& pos,
                       const Point& delta) override;
     void handle_pinch(const double scale_delta) override;
-    void handle_imagelist(const ImageListEvent event,
-                          const ImageEntryPtr& entry) override;
+    void handle_imagelist(const ChangeTracker& tracker) override;
 
 private:
     /**

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -429,6 +429,9 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
     } else {
         const ImageEntryPtr entry = add_file(abs_path, ordered);
         if (entry) {
+            if (fsmon) {
+                FsMonitor::self().add(path);
+            }
             return { entry };
         }
         return {};
@@ -487,9 +490,6 @@ ImageEntryPtr ImageList::add_file(const std::filesystem::path& path,
     entry->index = 0;
     if (!add_entry(entry, ordered)) {
         return nullptr;
-    }
-    if (fsmon) {
-        FsMonitor::self().add(path);
     }
     return entry;
 }

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <random>
 #include <string>
+#include <unordered_set>
 
 /**
  * Comparison of two localized strings.
@@ -141,6 +142,8 @@ ImageList& ImageList::self()
     return singleton;
 }
 
+// TODO: consider a refactor of set_entries to allow also loading directories
+// which would fully replace this
 ImageEntryPtr ImageList::load(const std::vector<std::filesystem::path>& sources)
 {
     if (sources.empty()) {
@@ -207,6 +210,91 @@ ImageEntryPtr ImageList::load(const std::filesystem::path& list_file)
     file.close();
 
     return load(sources);
+}
+
+ImageEntryPtr ImageList::set_entries(std::list<ImageEntryPtr>& added,
+                                     std::list<ImageEntryPtr>& removed,
+                                     const std::vector<std::string>& sources)
+{
+    std::unordered_set<std::filesystem::path> valid_paths;
+    std::vector<std::filesystem::path> source_order;
+    // ensure no unnecessary copying will happen
+    valid_paths.reserve(sources.size());
+    source_order.reserve(sources.size());
+
+    // First pass: gather source paths
+    for (auto& it : sources) {
+        if (ImageEntry::is_special(it)) {
+            valid_paths.insert(it);
+            source_order.emplace_back(it);
+        }
+
+        std::filesystem::path abs_path;
+        try {
+            abs_path = std::filesystem::absolute(it).lexically_normal();
+        } catch (...) {
+            Log::warning("Invalid path {}, skipped", it);
+            continue;
+        }
+        if (!std::filesystem::exists(abs_path)) {
+            Log::warning("File {} not found, skipped", abs_path.string());
+            continue;
+        }
+
+        const bool is_dir = std::filesystem::is_directory(abs_path);
+        if (is_dir || adjacent) {
+            iterate_dir(
+                [&](const std::filesystem::path& abs_path) {
+                    valid_paths.insert(abs_path);
+                    source_order.emplace_back(abs_path);
+                },
+                is_dir ? abs_path : abs_path.parent_path(), recursive, fsmon);
+        } else {
+            valid_paths.insert(abs_path);
+            source_order.emplace_back(abs_path);
+        }
+    }
+
+    const std::unique_lock lock(mutex);
+
+    // Second pass: remove entries not in filtered sources
+    entries.clear();
+    auto it = entry_map.begin();
+    while (it != entry_map.end()) {
+        // entry not in new sources -> remove it
+        // TODO: check perf vs .contains
+        if (valid_paths.erase(it->second->path) == 0) {
+            removed.push_back(it->second);
+            it->second->remove();
+            it = entry_map.erase(it);
+        } else {
+            it++;
+        }
+    }
+
+    // Third pass: add all entries in source order
+    entries.reserve(source_order.size());
+    for (const auto& src_path : source_order) {
+        const auto entry_it = entry_map.find(src_path);
+        if (entry_it != entry_map.end()) { // put back existing entry
+            entries.emplace_back(entry_it->second);
+        } else { // create and add new entry
+            const ImageEntryPtr entry = ImageEntry::is_special(src_path)
+                ? add_special_source(src_path, false)
+                : add_file(src_path, false);
+            if (entry) {
+                added.push_back(entry);
+            }
+        }
+    }
+
+    ImageEntryPtr first = entries.front();
+    sort(false);
+
+    // disable to prevent loading whole directories when user calls add()
+    adjacent = false;
+
+    return first;
 }
 
 std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path)

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -57,6 +57,17 @@ public:
     ImageEntryPtr load(const std::filesystem::path& list_file);
 
     /**
+     * Replace all entries in the list with new sources.
+     * @param sources list of sources to set
+     * @param on_added callback invoked for each added entry
+     * @param on_removed callback invoked for each removed entry
+     * @return first entry from source list
+     */
+    ImageEntryPtr set_entries(std::list<ImageEntryPtr>& added,
+                              std::list<ImageEntryPtr>& removed,
+                              const std::vector<std::string>& sources);
+
+    /**
      * Add file or special source to the list.
      * @param path path to the file or special source
      * @return list of added entries

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -151,7 +151,7 @@ private:
      * Add file to the list.
      * @param path path to the file
      * @param ordered flag to add new entry to ordered position in the list
-     * @return added entry
+     * @return added entry (nullptr if already exists)
      */
     ImageEntryPtr add_file(const std::filesystem::path& path,
                            const bool ordered);

--- a/src/luaengine.cpp
+++ b/src/luaengine.cpp
@@ -525,6 +525,10 @@ void LuaEngine::bind_imagelist_api()
                      [](const std::string& path) {
                          Application::self().remove_image_entry(path);
                      })
+        .addFunction("set",
+                     [](const std::vector<std::string>& paths) {
+                         Application::self().set_image_entries(paths);
+                     })
         .addFunction("set_order",
                      [this](const std::string& name) {
                          const auto order =

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -9,7 +9,6 @@
 #include "log.hpp"
 #include "render.hpp"
 #include "resources.hpp"
-#include "text.hpp"
 
 #include <cmath>
 #include <format>
@@ -587,34 +586,43 @@ void Viewer::handle_pinch(const double scale_delta)
     set_scale(scale + scale_delta * pinch_factor);
 }
 
-void Viewer::handle_imagelist(const ImageListEvent event,
-                              const ImageEntryPtr& entry)
+void Viewer::handle_imagelist(const AppMode::ChangeTracker& tracker)
 {
-    AppMode::handle_imagelist(event, entry);
+    AppMode::handle_imagelist(tracker);
 
-    if (event == ImageListEvent::Modify || event == ImageListEvent::Remove) {
-        // remove entry from cache
-        const std::scoped_lock lock(image_pool.mutex);
-        image_pool.history.get(entry);
-        image_pool.preload.get(entry);
+    // clear cache of invalidated entries, true if selected was cleared
+    const auto clear_cache = [this](const std::list<ImageEntryPtr>& to_clear) {
+        const auto current_entry = image->entry;
+        bool has_selected = false;
+        {
+            const std::scoped_lock lock(image_pool.mutex);
+
+            for (const auto& entry : to_clear) {
+                if (entry == current_entry) {
+                    has_selected = true;
+                }
+                // getting the image unloads it from storage unless added back
+                image_pool.history.get(entry);
+                image_pool.preload.get(entry);
+            }
+        }
+        return has_selected;
+    };
+
+    if (!tracker.removed.empty() && clear_cache(tracker.removed)) {
+        if (!open(ImageList::Dir::Next) && !open(ImageList::Dir::Prev)) {
+            Log::info("No more images to view, exit");
+            Application::self().exit(0);
+            return;
+        }
     }
 
-    switch (event) {
-        case ImageListEvent::Create:
-            preloader_start();
-            break;
-        case ImageListEvent::Modify:
-            if (entry == image->entry) {
-                reload();
-            }
-            break;
-        case ImageListEvent::Remove:
-            if (entry == image->entry && !open(ImageList::Dir::Next) &&
-                !open(ImageList::Dir::Prev)) {
-                Log::info("No more images to view, exit");
-                Application::self().exit(0);
-            }
-            break;
+    if (!tracker.modified.empty() && clear_cache(tracker.modified)) {
+        reload();
+    }
+
+    if (!tracker.added.empty()) {
+        preloader_start();
     }
 }
 

--- a/src/viewer.hpp
+++ b/src/viewer.hpp
@@ -224,8 +224,7 @@ public:
     void handle_mmove(const InputMouse& input, const Point& pos,
                       const Point& delta) override;
     void handle_pinch(const double scale_delta) override;
-    void handle_imagelist(const ImageListEvent event,
-                          const ImageEntryPtr& entry) override;
+    void handle_imagelist(const ChangeTracker& tracker) override;
 
 private:
     /**


### PR DESCRIPTION
Implementation of bulk list changes that allows swapping the entire imagelist for a set of different sources.

Improves supportability of #481 

The current implementation is the simplest way of supporting directories as well as files. Supporting just one wouldn't change much - other than removing the dir iterator.

I also fixed the FsMonitor to stop doing those linear lookups that were having signifficant impact on startup performance because of the need to check every single file when adding it. Now the startup takes about 1/3 of the time =)

PS: sorry for the large change. I tried multiple approaches to implementing this function and I kept running into duplicating a lot of code, so I ended up progressively adding extra changes to the underlying structure to allow a cleaner implementation (still not the prettiest, but there aren't that many options to make it better).

I have [an alternative implementation](https://github.com/litoj/swayimg/blob/fa9d42f357a7682316fef05696030be5652f84e0/src/imagelist.cpp#L231-L314), that avoids the inlined lambdas and adds the new files at the end instead, but it is slower.