### PR TITLE
fsmonitor: Improve lookup performance

### DIFF
--- a/src/fsmonitor.cpp
+++ b/src/fsmonitor.cpp
@@ -81,15 +81,10 @@ void FsMonitor::add(const std::filesystem::path& path)
     assert(path.is_absolute());
 
     // check if file is already watched by its parent
-    if (std::filesystem::is_regular_file(path)) {
-        const std::filesystem::path& parent = path.parent_path();
-        const auto it =
-            std::find_if(watch.begin(), watch.end(), [&parent](const auto& it) {
-                return parent == it.second.parent_path();
-            });
-        if (it != watch.end()) {
-            return; // already watched
-        }
+    if (watched.contains(std::filesystem::is_regular_file(path)
+                             ? path.parent_path()
+                             : path)) {
+        return;
     }
 
     const int wd =
@@ -102,21 +97,20 @@ void FsMonitor::add(const std::filesystem::path& path)
     }
 
     watch.insert(std::make_pair(wd, path));
+    watched.insert(path);
 }
 
 void FsMonitor::handle_event(const inotify_event* event)
 {
+    const auto it = watch.find(event->wd);
     if (event->mask & IN_IGNORED) {
         // remove from the watch list
-        watch.erase(event->wd);
+        watched.erase(it->second);
+        watch.erase(it);
         return;
     }
 
-    const auto it = watch.find(event->wd);
     assert(it != watch.end());
-    if (it == watch.end()) {
-        return;
-    }
 
     // compose full path
     std::filesystem::path path = it->second;

--- a/src/fsmonitor.hpp
+++ b/src/fsmonitor.hpp
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <filesystem>
-#include <map>
+#include <unordered_map>
+#include <unordered_set>
 
 struct inotify_event;
 
@@ -42,5 +43,6 @@ private:
     int fd = -1; ///< inotify file descriptor
 
     /** Watch descriptors linked to path. */
-    std::map<int, std::filesystem::path> watch;
+    std::unordered_map<int, std::filesystem::path> watch;
+    std::unordered_set<std::filesystem::path> watched;
 };


### PR DESCRIPTION
Cuts image loading time in half:
`@master: Image list loaded in 0.11`
`@this: Image list loaded in 0.6`