### PR TITLE
Consistent locking style

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -307,14 +307,17 @@ void Application::event_loop()
 {
     // register app event handler
     add_fdpoll(event_notify, [this]() {
-        std::unique_lock lock(event_mutex);
-        assert(!event_queue.empty());
-        const AppEvent::Holder event = event_queue.front();
-        event_queue.pop_front();
-        if (event_queue.empty()) {
-            event_notify.reset();
+        AppEvent::Holder event;
+        {
+            const std::scoped_lock lock(event_mutex);
+            assert(!event_queue.empty());
+            event = event_queue.front();
+            event_queue.pop_front();
+            if (event_queue.empty()) {
+                event_notify.reset();
+            }
         }
-        lock.unlock();
+
         handle_event(event);
     });
 

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -147,13 +147,13 @@ ImageEntryPtr ImageList::load(const std::vector<std::filesystem::path>& sources)
         return nullptr;
     }
 
-    mutex.lock();
-    entries_arr.reserve(sources.size());
-    for (auto& it : sources) {
-        add(it, false);
+    {
+        const std::scoped_lock lock(mutex);
+        for (auto& it : sources) {
+            add(it, false);
+        }
+        sort();
     }
-    sort();
-    mutex.unlock();
 
     // disable loading of adjacent files, otherwise fs mon will add unnecessary
     // files to the list
@@ -211,7 +211,7 @@ ImageEntryPtr ImageList::load(const std::filesystem::path& list_file)
 
 std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path)
 {
-    const std::unique_lock lock(mutex);
+    const std::scoped_lock lock(mutex);
     return add(path, true);
 }
 
@@ -223,7 +223,7 @@ ImageEntryPtr ImageList::remove(const ImageEntryPtr& entry, const bool forward)
 
     ImageEntryPtr next = get(entry, forward ? Dir::Next : Dir::Prev);
 
-    const std::unique_lock lock(mutex);
+    const std::scoped_lock lock(mutex);
 
     entries_map.erase(entry->path);
     entries_arr.erase(entries_arr.begin() + entry->index);
@@ -244,7 +244,7 @@ void ImageList::set_order(const Order new_order)
 {
     if (order != new_order || new_order == Order::Random) {
         order = new_order;
-        const std::unique_lock lock(mutex);
+        const std::scoped_lock lock(mutex);
         sort();
     }
 }
@@ -253,7 +253,7 @@ void ImageList::set_reverse(const bool enable)
 {
     if (reverse != enable) {
         reverse = enable;
-        const std::unique_lock lock(mutex);
+        const std::scoped_lock lock(mutex);
         sort();
     }
 }

--- a/src/threadpool.cpp
+++ b/src/threadpool.cpp
@@ -68,7 +68,7 @@ void ThreadPool::wait(const std::vector<size_t>& tids)
 
 void ThreadPool::cancel()
 {
-    const std::unique_lock lock(mutex);
+    const std::scoped_lock lock(mutex);
     tasks.clear();
 }
 

--- a/src/threadpool.hpp
+++ b/src/threadpool.hpp
@@ -51,10 +51,11 @@ public:
         auto task_fn =
             std::bind(std::forward<F>(fn), std::forward<Args>(args)...);
 
-        mutex.lock();
-        task_id = ++last_id;
-        tasks.emplace_back(Task { task_id, task_fn });
-        mutex.unlock();
+        {
+            const std::scoped_lock lock(mutex);
+            task_id = ++last_id;
+            tasks.emplace_back(Task { task_id, task_fn });
+        }
 
         tnotify.notify_one();
 


### PR DESCRIPTION
Prefer using scoped_lock as it is in most of the codebase. Also prefer using scoped_lock and arbitrary code block over mutex.lock/unlock.

There is a deadlock that I am trying to get rid of. Ensuring that gallery is consistent in _not_ locking calls to `Application::redraw()` unfortunately didn't resolve it.

So I did what I could to make everything as clear as possible in the process in case I'd discover more stuff like that locked Application::redraw call.