### PR TITLE
Separate dir iteration and skip redundant fsmonitor calls

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -28,6 +28,38 @@ bool ImageEntry::is_special(const std::string& path)
         path.starts_with(ImageEntry::SRC_EXEC);
 }
 
+ImageEntryPtr ImageEntry::from_special(const std::filesystem::path& path)
+{
+    assert(ImageEntry::is_special(path));
+
+    ImageEntryPtr entry = std::make_shared<ImageEntry>();
+    entry->path = path;
+    entry->mtime = 0;
+    entry->size = 0;
+    entry->index = 0;
+    return entry;
+}
+
+ImageEntryPtr ImageEntry::from_file(const std::filesystem::path& path)
+{
+    assert(path.is_absolute());
+    assert(std::filesystem::is_regular_file(path));
+
+    const auto fs_time = std::filesystem::last_write_time(path);
+    auto sys_time =
+        std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+            fs_time - std::filesystem::file_time_type::clock::now() +
+            std::chrono::system_clock::now());
+    const std::time_t tt_time = std::chrono::system_clock::to_time_t(sys_time);
+
+    ImageEntryPtr entry = std::make_shared<ImageEntry>();
+    entry->path = path;
+    entry->mtime = tt_time;
+    entry->size = std::filesystem::file_size(path);
+    entry->index = 0;
+    return entry;
+}
+
 void Image::draw(const size_t frame, Pixmap& target, const double scale,
                  const ssize_t x, const ssize_t y)
 {

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -42,6 +42,24 @@ struct ImageEntry {
      * @return true if path starts with stdin:// or exec://
      */
     static bool is_special(const std::string& path);
+
+    /**
+     * Create a new stdin:// or exec:// entry.
+     * @param path path representing the special source
+     * @param ordered flag to add new entry to ordered position in the list
+     * @return pointer to created entry
+     */
+    static std::shared_ptr<ImageEntry>
+    from_special(const std::filesystem::path& path);
+
+    /**
+     * Create a new path entry.
+     * @param path path to the file
+     * @param ordered flag to add new entry to ordered position in the list
+     * @return pointer to created entry
+     */
+    static std::shared_ptr<ImageEntry>
+    from_file(const std::filesystem::path& path);
 };
 
 using ImageEntryPtr = std::shared_ptr<ImageEntry>;

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -417,8 +417,8 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
                                         const bool ordered)
 {
     if (ImageEntry::is_special(path)) {
-        const ImageEntryPtr entry = add_special_source(path, ordered);
-        if (entry) {
+        const ImageEntryPtr entry = ImageEntry::from_special(path);
+        if (add_entry(entry, ordered)) {
             return { entry };
         }
         return {};
@@ -441,7 +441,10 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
     if (is_dir || adjacent) {
         iterate_dir(
             [&](const std::filesystem::path& abs_path) {
-                added.emplace_back(add_file(abs_path, false));
+                const ImageEntryPtr entry = ImageEntry::from_file(abs_path);
+                if (add_entry(entry, false)) {
+                    added.emplace_back(entry);
+                }
             },
             is_dir ? abs_path : abs_path.parent_path(), recursive, fsmon);
 
@@ -451,51 +454,15 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
     } else if (!std::filesystem::is_regular_file(abs_path)) {
         Log::warning("File {} is not regular, skipped", abs_path.string());
     } else {
-        added.emplace_back(add_file(abs_path, ordered));
+        const ImageEntryPtr entry = ImageEntry::from_file(abs_path);
+        if (add_entry(entry, ordered)) {
+            if (fsmon) {
+                FsMonitor::self().add(path);
+            }
+            added.emplace_back(entry);
+        }
     }
     return added;
-}
-
-ImageEntryPtr ImageList::add_file(const std::filesystem::path& path,
-                                  const bool ordered)
-{
-    assert(path.is_absolute());
-
-    const auto fs_time = std::filesystem::last_write_time(path);
-    auto sys_time =
-        std::chrono::time_point_cast<std::chrono::system_clock::duration>(
-            fs_time - std::filesystem::file_time_type::clock::now() +
-            std::chrono::system_clock::now());
-    const std::time_t tt_time = std::chrono::system_clock::to_time_t(sys_time);
-
-    ImageEntryPtr entry = std::make_shared<ImageEntry>();
-    entry->path = path;
-    entry->mtime = tt_time;
-    entry->size = std::filesystem::file_size(path);
-    entry->index = 0;
-    if (!add_entry(entry, ordered)) {
-        return nullptr;
-    }
-    if (fsmon) {
-        FsMonitor::self().add(path);
-    }
-    return entry;
-}
-
-ImageEntryPtr ImageList::add_special_source(const std::filesystem::path& path,
-                                            const bool ordered)
-{
-    assert(ImageEntry::is_special(path));
-
-    ImageEntryPtr entry = std::make_shared<ImageEntry>();
-    entry->path = path;
-    entry->mtime = 0;
-    entry->size = 0;
-    entry->index = 0;
-    if (add_entry(entry, ordered)) {
-        return entry;
-    }
-    return nullptr;
 }
 
 bool ImageList::add_entry(const ImageEntryPtr& entry, const bool ordered)

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -135,6 +135,28 @@ static bool compare_entries(const ImageEntry& l, const ImageEntry& r,
     return false;
 }
 
+static void
+iterate_dir(const std::function<void(const std::filesystem::path&)>& action,
+            const std::filesystem::path& source, const bool recursive,
+            const bool fsmon)
+{
+    if (fsmon) {
+        FsMonitor::self().add(source);
+    }
+    try {
+        for (const auto& it : std::filesystem::directory_iterator(source)) {
+            if (std::filesystem::is_directory(it)) {
+                if (recursive) {
+                    iterate_dir(action, it, true, fsmon);
+                }
+            } else if (std::filesystem::is_regular_file(it)) {
+                action(it);
+            }
+        }
+    } catch (const std::filesystem::filesystem_error&) {
+    }
+}
+
 ImageList& ImageList::self()
 {
     static ImageList singleton;
@@ -414,52 +436,23 @@ std::list<ImageEntryPtr> ImageList::add(const std::filesystem::path& path,
         return {};
     }
 
-    if (std::filesystem::is_directory(abs_path)) {
-        std::list<ImageEntryPtr> added = add_dir(abs_path);
-        if (!added.empty() && ordered) {
-            sort();
-        }
-        return added;
-    } else if (adjacent) {
-        std::list<ImageEntryPtr> added = add_dir(abs_path.parent_path());
-        if (!added.empty() && ordered) {
-            sort();
-        }
-        return added;
-    } else {
-        const ImageEntryPtr entry = add_file(abs_path, ordered);
-        if (entry) {
-            return { entry };
-        }
-        return {};
-    }
-}
-
-std::list<ImageEntryPtr> ImageList::add_dir(const std::filesystem::path& path)
-{
     std::list<ImageEntryPtr> added;
+    const bool is_dir = std::filesystem::is_directory(abs_path);
+    if (is_dir || adjacent) {
+        iterate_dir(
+            [&](const std::filesystem::path& abs_path) {
+                added.emplace_back(add_file(abs_path, false));
+            },
+            is_dir ? abs_path : abs_path.parent_path(), recursive, fsmon);
 
-    if (fsmon) {
-        FsMonitor::self().add(path);
-    }
-
-    try {
-        for (const auto& it : std::filesystem::directory_iterator(path)) {
-            const std::filesystem::path& sub_path = it.path();
-            if (std::filesystem::is_directory(sub_path)) {
-                if (recursive) {
-                    added.splice(added.end(), add_dir(sub_path));
-                }
-            } else {
-                const ImageEntryPtr entry = add_file(sub_path, false);
-                if (entry) {
-                    added.emplace_back(entry);
-                }
-            }
+        if (!added.empty() && ordered) {
+            sort();
         }
-    } catch (const std::filesystem::filesystem_error&) {
+    } else if (!std::filesystem::is_regular_file(abs_path)) {
+        Log::warning("File {} is not regular, skipped", abs_path.string());
+    } else {
+        added.emplace_back(add_file(abs_path, ordered));
     }
-
     return added;
 }
 
@@ -467,11 +460,6 @@ ImageEntryPtr ImageList::add_file(const std::filesystem::path& path,
                                   const bool ordered)
 {
     assert(path.is_absolute());
-
-    if (!std::filesystem::is_regular_file(path)) {
-        Log::warning("File {} is not a regular, skipped", path.string());
-        return nullptr;
-    }
 
     const auto fs_time = std::filesystem::last_write_time(path);
     auto sys_time =

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -141,24 +141,6 @@ private:
                                  const bool ordered);
 
     /**
-     * Add file to the list.
-     * @param path path to the file
-     * @param ordered flag to add new entry to ordered position in the list
-     * @return added entry (nullptr if already exists)
-     */
-    ImageEntryPtr add_file(const std::filesystem::path& path,
-                           const bool ordered);
-
-    /**
-     * Add a special source (stdin://, exec://) to the list.
-     * @param path path representing the special source
-     * @param ordered flag to add new entry to ordered position in the list
-     * @return added entry (nullptr if already exists)
-     */
-    ImageEntryPtr add_special_source(const std::filesystem::path& path,
-                                     const bool ordered);
-
-    /**
      * Add new entry to the list.
      * @param entry image entry to add
      * @param ordered flag to add new entry to ordered position in the list

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -141,17 +141,10 @@ private:
                                  const bool ordered);
 
     /**
-     * Add files from the directory to the list.
-     * @param path path to the directory
-     * @return list with added entries
-     */
-    std::list<ImageEntryPtr> add_dir(const std::filesystem::path& path);
-
-    /**
      * Add file to the list.
      * @param path path to the file
      * @param ordered flag to add new entry to ordered position in the list
-     * @return added entry
+     * @return added entry (nullptr if already exists)
      */
     ImageEntryPtr add_file(const std::filesystem::path& path,
                            const bool ordered);


### PR DESCRIPTION
Generalizes recursive directory iteration to be reusable by more than just one method.