### PR TITLE
gallery: Avoid unnecessary redrawing

### DIFF
--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -406,6 +406,7 @@ void Gallery::handle_imagelist(const ImageListEvent event,
                     return;
                 }
                 switch_current();
+                break;
             }
         }
     }
@@ -607,13 +608,16 @@ void Gallery::load_thumbnail(const ImageEntryPtr& entry)
     }
 
     const std::scoped_lock lock(mutex);
-
+    active.erase(entry);
     if (pm) {
         cache.insert_or_assign(entry, pm);
+    } else {
+        return; // to be removed -> reflow/redraw handled via the event
     }
-    active.erase(entry);
 
-    Application::redraw();
+    if (layout.is_visible(entry)) {
+        Application::redraw();
+    }
 }
 
 void Gallery::queue_thumbnail(const ImageEntryPtr& entry)

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -229,6 +229,13 @@ ImageEntryPtr Layout::get_selected() const
     return sel_entry;
 }
 
+bool Layout::is_visible(const ImageEntryPtr& entry) const
+{
+    ImageList& il = ImageList::self();
+    return il.distance(entry, scheme.front().img) <= 0 &&
+        il.distance(entry, scheme.back().img) >= 0;
+}
+
 const std::vector<Layout::Thumbnail>& Layout::get_scheme() const
 {
     return scheme;

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -103,6 +103,13 @@ public:
     [[nodiscard]] ImageEntryPtr get_selected() const;
 
     /**
+     * Check if give entry is visible (is in the current scheme).
+     * @param entry entry to check if included in the scheme
+     * @return true if visible (part of the current scheme)
+     */
+    [[nodiscard]] bool is_visible(const ImageEntryPtr& entry) const;
+
+    /**
      * Get layout scheme.
      * @return array with thumbnails layout description
      */


### PR DESCRIPTION
in #506 the problem was that I was using `il.distance()` as a `cmp` method, but its value is actually the opposite of that -> changing `<=` to `>=` is all that was needed