### PR TITLE
Support empty image list and no selection

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -816,14 +816,13 @@ This function adds a file to the image list and then opens it in the viewer.
 ### swayimg.viewer.get_image
 
 ```lua
-swayimg.viewer.get_image() -> swayimg.image
+swayimg.viewer.get_image()
 ```
 
 Get information about currently displayed image.
 
 Since 5.0.
-
-@_return_ - Currently displayed image
+@return swayimg.image? # Currently displayed image
 
 ### swayimg.viewer.reload
 
@@ -1461,14 +1460,13 @@ This function adds a file to the image list and then opens it in the viewer.
 ### swayimg.slideshow.get_image
 
 ```lua
-swayimg.slideshow.get_image() -> swayimg.image
+swayimg.slideshow.get_image()
 ```
 
 Get information about currently displayed image.
 
 Since 5.0.
-
-@_return_ - Currently displayed image
+@return swayimg.image? # Currently displayed image
 
 ### swayimg.slideshow.reload
 
@@ -2091,14 +2089,13 @@ Since 5.3.
 ### swayimg.gallery.get_image
 
 ```lua
-swayimg.gallery.get_image() -> swayimg.entry
+swayimg.gallery.get_image()
 ```
 
 Get information about currently selected image entry.
 
 Since 5.0.
-
-@_return_ - Currently selected image entry
+@return swayimg.entry? # Currently selected image entry
 
 ### swayimg.gallery.set_aspect
 

--- a/extra/swayimg.lua
+++ b/extra/swayimg.lua
@@ -479,7 +479,7 @@ function swayimg.viewer.open(path) end
 
 ---Get information about currently displayed image.
 ---Since 5.0.
----@return swayimg.image # Currently displayed image
+---@return swayimg.image? # Currently displayed image
 function swayimg.viewer.get_image() end
 
 ---Reload current image.
@@ -673,7 +673,7 @@ function swayimg.gallery.reload() end
 
 ---Get information about currently selected image entry.
 ---Since 5.0.
----@return swayimg.entry # Currently selected image entry
+---@return swayimg.entry? # Currently selected image entry
 function swayimg.gallery.get_image() end
 
 ---Set thumbnail aspect ratio.

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -58,10 +58,6 @@ int Application::run()
     // initialize filemon and image list
     FsMonitor::self().initialize();
     const ImageEntryPtr first_entry = il_initialize();
-    if (!first_entry) {
-        Log::info("Image list is empty, exit");
-        return 0;
-    }
 
     // initialize UI
     ui.reset(ui_init_wayland());

--- a/src/appmode.cpp
+++ b/src/appmode.cpp
@@ -58,8 +58,9 @@ void AppMode::handle_imagelist(const ImageListEvent,
                                const std::list<ImageEntryPtr>&)
 {
     Text& text = Text::self();
+    const ImageEntryPtr& selected = get_current();
     text.set_field(Text::FIELD_LIST_INDEX,
-                   std::to_string(get_current()->index + 1));
+                   selected ? std::to_string(selected->index + 1) : "");
     text.set_field(Text::FIELD_LIST_TOTAL,
                    std::to_string(ImageList::self().size()));
     text.update();
@@ -131,8 +132,9 @@ void AppMode::switch_current()
 
     // set window title
     Ui* ui = Application::self().get_ui();
-    const std::string title =
-        std::format("Swayimg: {}", current->path.filename().string());
+    const std::string title = current
+        ? std::format("Swayimg: {}", current->path.filename().string())
+        : "Swayimg";
     ui->set_title(title.c_str());
 
     // update text layer

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -7,7 +7,6 @@
 #include "application.hpp"
 #include "imageformat.hpp"
 #include "imagelist.hpp"
-#include "log.hpp"
 #include "render.hpp"
 #include "resources.hpp"
 #include "text.hpp"
@@ -352,6 +351,9 @@ void Gallery::window_redraw(Pixmap& wnd)
     wnd.fill({ 0, 0, wnd.width(), wnd.height() }, clr_window);
 
     const ImageEntryPtr current = layout.get_selected();
+    if (!current) {
+        return;
+    }
 
     const auto& scheme = layout.get_scheme();
     size_t selected_scheme_idx = 0;
@@ -396,14 +398,17 @@ void Gallery::handle_imagelist(const ImageListEvent event,
         }
     }
 
-    if (event == ImageListEvent::Remove) {
+    if (event == ImageListEvent::Create) {
+        if (!layout.get_selected()) {
+            layout.select(entries.front());
+            switch_current();
+        }
+    } else if (event == ImageListEvent::Remove) {
         for (const auto& entry : entries) {
             if (entry == layout.get_selected()) {
                 if (!layout.select(Layout::Right) &&
                     !layout.select(Layout::Left)) {
-                    Log::info("No more images to view, exit");
-                    Application::self().exit(0);
-                    return;
+                    layout.select(nullptr);
                 }
                 switch_current();
                 break;
@@ -518,37 +523,38 @@ void Gallery::load_thumbnails()
 
     ImageList& il = ImageList::self();
     const std::vector<Layout::Thumbnail>& scheme = layout.get_scheme();
+    if (scheme.empty()) {
+        return;
+    }
 
-    const size_t index_first = scheme.front().img->index;
-    const size_t index_last = scheme.back().img->index;
+    size_t index_min = scheme.front().img->index;
+    size_t index_max = scheme.back().img->index;
 
-    size_t preload_counter = preload ? cache_size : 0;
+    if (preload) {
+        size_t extra = cache_size;
+        const size_t min = index_min < extra / 2 ? 0 : index_min - extra / 2;
+        extra -= index_min - min; // number of scheduled preceeding entries
+
+        const size_t max = std::min(il.size(), index_max + extra);
+        extra -= max - index_max; // number of scheduled following entries
+
+        index_min = min < extra ? 0 : min - extra; // following overflow
+        index_max = max;
+    }
 
     ImageEntryPtr fwd = layout.get_selected();
-    ImageEntryPtr back = il.get(fwd, ImageList::Dir::Prev);
+    ImageEntryPtr bwd = il.get(fwd, ImageList::Dir::Prev);
 
-    while (fwd || back) {
+    while (fwd || bwd) {
         if (fwd) {
             queue_thumbnail(fwd);
-            fwd = il.get(fwd, ImageList::Dir::Next);
-            if (fwd && fwd->index > index_last) {
-                if (preload_counter) {
-                    --preload_counter;
-                } else {
-                    fwd = nullptr;
-                }
-            }
+            fwd = fwd->index < index_max ? il.get(fwd, ImageList::Dir::Next)
+                                         : nullptr;
         }
-        if (back) {
-            queue_thumbnail(back);
-            back = il.get(back, ImageList::Dir::Prev);
-            if (back && back->index < index_first) {
-                if (preload_counter) {
-                    --preload_counter;
-                } else {
-                    back = nullptr;
-                }
-            }
+        if (bwd) {
+            queue_thumbnail(bwd);
+            bwd = index_min < bwd->index ? il.get(bwd, ImageList::Dir::Prev)
+                                         : nullptr;
         }
     }
 }

--- a/src/imagelist.cpp
+++ b/src/imagelist.cpp
@@ -315,6 +315,7 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const Dir dir)
     if (entries_arr.empty()) {
         return nullptr;
     }
+
     if (dir == Dir::First) {
         return entries_arr.front();
     }
@@ -322,14 +323,14 @@ ImageEntryPtr ImageList::get(const ImageEntryPtr& from, const Dir dir)
         return entries_arr.back();
     }
 
-    assert(from);
+    if (!from) {
+        return is_forward(dir) ? entries_arr.front() : entries_arr.back();
+    }
 
     // handle removed entry: return nearest entry
     if (from->removed) {
         size_t index = from->index;
-        if (index &&
-            (dir == ImageList::Dir::Prev ||
-             dir == ImageList::Dir::PrevParent)) {
+        if (index && !is_forward(dir)) {
             --index;
         }
         index = std::min(index, entries_arr.size() - 1);

--- a/src/imagelist.hpp
+++ b/src/imagelist.hpp
@@ -27,14 +27,20 @@ public:
 
     /** Direction of the next entry. */
     enum class Dir : uint8_t {
-        First,      ///< First entry in the list
         Last,       ///< Last entry in the list
+        First,      ///< First entry in the list
         Next,       ///< Next entry
         Prev,       ///< Previous entry
         NextParent, ///< Next entry with different parent
         PrevParent, ///< Previous entry with different parent
         Random      ///< Random entry
     };
+
+    constexpr static bool is_forward(const Dir dir)
+    {
+        return dir == Dir::Last || dir == Dir::Next || dir == Dir::NextParent ||
+            dir == Dir::Random;
+    }
 
     /**
      * Get global instance of image list.

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -19,6 +19,10 @@ void Layout::update()
     const ImageEntryPtr first_entry = il.get(nullptr, ImageList::Dir::First);
 
     if (!sel_entry) {
+        if (!first_entry) {
+            scheme.clear();
+            return;
+        }
         sel_entry = first_entry;
     }
     assert(!sel_entry->removed);
@@ -118,12 +122,16 @@ void Layout::select(const ImageEntryPtr& image)
 {
     sel_entry = image;
     sel_row = std::numeric_limits<size_t>::max();
-    update();
+    if (image) {
+        update();
+    }
 }
 
 bool Layout::select(const Direction dir)
 {
-    assert(sel_entry);
+    if (!sel_entry) {
+        return false;
+    }
 
     ImageList& il = ImageList::self();
     ImageEntryPtr next = nullptr;
@@ -231,6 +239,10 @@ ImageEntryPtr Layout::get_selected() const
 
 bool Layout::is_visible(const ImageEntryPtr& entry) const
 {
+    if (scheme.empty()) {
+        return false;
+    }
+
     ImageList& il = ImageList::self();
     return il.distance(entry, scheme.front().img) <= 0 &&
         il.distance(entry, scheme.back().img) >= 0;

--- a/src/luaengine.cpp
+++ b/src/luaengine.cpp
@@ -687,6 +687,9 @@ void LuaEngine::bind_viewer_api(const char* name)
                      [this, ensure_active, mode]() {
                          ensure_active("get_image");
                          const ImagePtr image = mode->current_image();
+                         if (!image->entry) {
+                             return luabridge::LuaRef(lua_state);
+                         }
                          luabridge::LuaRef tbl = entry_to_table(*image->entry);
                          tbl["format"] = image->format;
                          tbl["frames"] = image->frames.size();
@@ -985,14 +988,14 @@ void LuaEngine::bind_gallery_api()
                          ensure_active("reload");
                          Gallery::self().reload();
                      })
-        .addFunction(
-            "get_image",
-            [this, ensure_active]() {
-                ensure_active("get_image");
-                luabridge::LuaRef table = entry_to_table(
-                    *Application::self().current_mode()->get_current());
-                return table;
-            })
+        .addFunction("get_image",
+                     [this, ensure_active]() {
+                         ensure_active("get_image");
+                         const ImageEntryPtr& entry =
+                             Gallery::self().get_current();
+                         return entry ? entry_to_table(*entry)
+                                      : luabridge::LuaRef(lua_state);
+                     })
         .addFunction(
             "set_aspect",
             [this](const std::string& name) {

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -191,6 +191,9 @@ void Text::reset(const ImagePtr& image)
     assert(image);
 
     reset(image->entry);
+    if (!image->entry) {
+        return;
+    }
 
     set_field(FIELD_IMAGE_FORMAT, image->format);
     set_field(FIELD_FRAME_TOTAL, std::to_string(image->frames.size()));
@@ -206,16 +209,20 @@ void Text::reset(const ImagePtr& image)
 
 void Text::reset(const ImageEntryPtr& entry)
 {
-    assert(entry);
-
     fields.clear();
+
+    set_field(FIELD_LIST_TOTAL, std::to_string(ImageList::self().size()));
+
+    if (!entry) {
+        update();
+        return;
+    }
 
     set_field(FIELD_FILE_PATH, entry->path);
     set_field(FIELD_FILE_DIR, entry->path.parent_path().filename());
     set_field(FIELD_FILE_NAME, entry->path.filename());
     set_field(FIELD_FILE_SIZE, std::to_string(entry->size));
     set_field(FIELD_LIST_INDEX, std::to_string(entry->index + 1));
-    set_field(FIELD_LIST_TOTAL, std::to_string(ImageList::self().size()));
 
     // human readable file size
     const size_t mib = 1024 * 1024;

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -18,6 +18,9 @@
 /** Max scale factor. */
 constexpr double MAX_SCALE = 100.0;
 
+// defaults set on mode creation
+const ImagePtr Viewer::EMPTY_IMAGE = std::make_shared<Image>();
+
 Viewer& Viewer::self()
 {
     static Viewer singleton;
@@ -26,6 +29,11 @@ Viewer& Viewer::self()
 
 Viewer::Viewer()
 {
+    if (EMPTY_IMAGE->frames.empty()) {
+        EMPTY_IMAGE->frames.emplace_back(Image::Frame {});
+    }
+    image = EMPTY_IMAGE;
+
     // default settings
 
     auto_center = true;
@@ -182,20 +190,14 @@ Viewer::Viewer()
 
 bool Viewer::open(const ImageList::Dir dir)
 {
-    assert(image);
-
-    const bool forward = dir == ImageList::Dir::Last ||
-        dir == ImageList::Dir::Random || dir == ImageList::Dir::Next ||
-        dir == ImageList::Dir::NextParent;
     const ImageEntryPtr next = ImageList::self().get(image->entry, dir);
-    return open(next, forward);
+    return open(next, ImageList::is_forward(dir));
 }
 
 bool Viewer::reload()
 {
     if (!open(image->entry, true) && !open(image->entry, false)) {
-        Log::info("No more images to view, exit");
-        Application::self().exit(0);
+        set_image(EMPTY_IMAGE);
         return false;
     }
     return true;
@@ -461,11 +463,11 @@ void Viewer::activate(const ImageEntryPtr& entry, const Size& wnd)
 
     window_size = wnd;
 
-    if (image && image->entry == entry && !entry->removed) {
+    if (image->entry == entry && entry && !entry->removed) {
         set_image(image); // reinit state without reloading image
     } else if (!open(entry, true) && !open(entry, false)) {
-        Log::info("No more images to view, exit");
-        Application::self().exit(0);
+        set_image(EMPTY_IMAGE);
+        Log::verbose("No selected image");
     }
 }
 
@@ -481,7 +483,7 @@ void Viewer::deactivate()
 
 ImageEntryPtr Viewer::get_current()
 {
-    return image ? image->entry : nullptr;
+    return image->entry;
 }
 
 bool Viewer::set_current(const ImageEntryPtr& entry)
@@ -490,7 +492,7 @@ bool Viewer::set_current(const ImageEntryPtr& entry)
 
     ImagePtr new_image = nullptr;
 
-    if (image && image->entry == entry) {
+    if (image->entry == entry) {
         // remove entry from cache in reloading mode
         const std::scoped_lock lock(image_pool.mutex);
         image_pool.history.get(entry);
@@ -567,7 +569,7 @@ void Viewer::window_redraw(Pixmap& wnd)
     }
 
     // mark icon
-    if (image->entry->mark) {
+    if (image->entry && image->entry->mark) {
         const ssize_t margin = 10;
         const ssize_t x = static_cast<ssize_t>(wnd.width()) -
             static_cast<ssize_t>(Resource::mark.width()) - margin;
@@ -607,6 +609,9 @@ void Viewer::handle_imagelist(const ImageListEvent event,
     switch (event) {
         case ImageListEvent::Create:
             preloader_start();
+            if (!image->entry) {
+                set_current(entries.front());
+            }
             break;
         case ImageListEvent::Modify:
             for (const auto& entry : entries) {
@@ -617,11 +622,8 @@ void Viewer::handle_imagelist(const ImageListEvent event,
             }
             break;
         case ImageListEvent::Remove:
-            if (image->entry->removed && !open(image->entry, true) &&
-                !open(image->entry, false)) {
-                Log::info("No more images to view, exit");
-                Application::self().exit(0);
-                return;
+            if (image->entry && image->entry->removed) {
+                reload();
             }
             break;
     }
@@ -631,13 +633,11 @@ bool Viewer::open(const ImageEntryPtr& entry, const bool forward)
 {
     ImageList& il = ImageList::self();
 
+    const ImageList::Dir dir =
+        forward ? ImageList::Dir::Next : ImageList::Dir::Prev;
     ImageEntryPtr next = entry;
-    if (!next) {
-        next = il.get(nullptr,
-                      forward ? ImageList::Dir::First : ImageList::Dir::Last);
-    } else if (next->removed) {
-        next =
-            il.get(next, forward ? ImageList::Dir::Next : ImageList::Dir::Prev);
+    if (!next || next->removed) {
+        next = il.get(next, dir);
     }
 
     while (next) {
@@ -646,21 +646,19 @@ bool Viewer::open(const ImageEntryPtr& entry, const bool forward)
         }
         next = il.remove(next, forward);
 
+        // start a new loop
         if (!next && imagelist_loop && il.size() > 0) {
-            // reshuffle random on new loop
             if (il.get_order() == ImageList::Order::Random) {
+                // reshuffle on new loop
                 il.set_order(ImageList::Order::Random);
-            }
 
-            // start new loop
-            const ImageList::Dir dir =
-                forward ? ImageList::Dir::First : ImageList::Dir::Last;
-            next = il.get(nullptr, dir);
+                next = il.get(nullptr, dir);
 
-            // avoid opening the same image in random mode
-            if (next && next == entry &&
-                il.get_order() == ImageList::Order::Random) {
-                next = il.get(next, ImageList::Dir::Next);
+                if (next == entry) { // ensure a new result
+                    next = il.get(next, ImageList::Dir::Next);
+                }
+            } else {
+                next = il.get(nullptr, dir);
             }
         }
     }
@@ -669,7 +667,7 @@ bool Viewer::open(const ImageEntryPtr& entry, const bool forward)
 
 void Viewer::set_image(const ImagePtr& img)
 {
-    if (image && image != img) {
+    if (image != img) {
         // put current image to history
         const std::scoped_lock lock(image_pool.mutex);
         image_pool.history.put(image);
@@ -732,6 +730,10 @@ void Viewer::update_text(const TextUpdate what) const
 
     if (what == TextUpdate::All) {
         text.reset(image);
+    }
+
+    if (!image->entry) {
+        return;
     }
 
     if (what == TextUpdate::All || what == TextUpdate::Frame) {

--- a/src/viewer.hpp
+++ b/src/viewer.hpp
@@ -320,6 +320,8 @@ public:
     Position default_pos;                      ///< Default image position
 
 private:
+    const static ImagePtr EMPTY_IMAGE;
+
     ImagePtr image; ///< Currently shown image
     Point position; ///< Image position on the window
     double scale;   ///< Current scale factor of the image


### PR DESCRIPTION
In order to avoid crashes in situations where the user happens to remove all entries, but the continues working in lua interacting with the image list (for example by adding some images back), the modes need to be able to have a null selected.

This is already the state at initialization, but it wasn't expected by the modes while active. So for the most part this was just making it accept an empty selected entry also while being active and during rendering (that's why a dummy ImagePtr was introduced).

In order to not go over the "complexity" check because of the simple `if(!image->entry) return;` I had to rewrite the thumbnail scheduler.

The `imagelist::get` can now resolve nullptr in combination with any direction.

Edit: sorry for the repeated commits. I had a good idea, but pushed it half-done, so I had to push again to fix it properly.