### PR TITLE
gallery: Separate thumb scheduling and rendering

### DIFF
--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -199,6 +199,8 @@ bool Gallery::select(const Layout::Direction dir)
     if (!layout.select(dir)) {
         return false;
     }
+    clear_invisible_thumbnails();
+    load_thumbnails();
     switch_current();
     return true;
 }
@@ -209,11 +211,13 @@ void Gallery::reload()
     tpool.cancel();
     tpool.wait();
 
-    // clear cache
-    const std::scoped_lock lock(mutex);
-    cache.clear();
+    {
+        // clear cache
+        const std::scoped_lock lock(mutex);
+        cache.clear();
+    }
 
-    Application::redraw();
+    load_thumbnails();
 }
 
 void Gallery::set_thumb_aspect(const Aspect ratio)
@@ -319,8 +323,7 @@ void Gallery::activate(const ImageEntryPtr& entry, const Size& wnd)
 {
     AppMode::activate(entry, wnd);
     layout.set_window_size(wnd);
-    layout.select(entry);
-    switch_current();
+    set_current(entry);
 }
 
 void Gallery::deactivate()
@@ -337,18 +340,21 @@ ImageEntryPtr Gallery::get_current()
 bool Gallery::set_current(const ImageEntryPtr& entry)
 {
     layout.select(entry);
-    Application::redraw();
+    clear_invisible_thumbnails();
+    load_thumbnails();
+    switch_current();
     return true;
 }
 
 void Gallery::window_resize(const Size& wnd)
 {
     layout.set_window_size(wnd);
+    clear_invisible_thumbnails();
+    load_thumbnails();
 }
 
 void Gallery::window_redraw(Pixmap& wnd)
 {
-    layout.update();
     wnd.fill({ 0, 0, wnd.width(), wnd.height() }, clr_window);
 
     const ImageEntryPtr current = layout.get_selected();
@@ -366,9 +372,6 @@ void Gallery::window_redraw(Pixmap& wnd)
         }
     }
     draw(scheme[selected_scheme_idx], wnd);
-
-    load_thumbnails();
-    clear_invisible_thumbnails();
 }
 
 void Gallery::handle_mmove(const InputMouse&, const Point& pos, const Point&)
@@ -412,6 +415,9 @@ void Gallery::handle_imagelist(const ImageListEvent event,
     }
 
     layout.update();
+    clear_invisible_thumbnails();
+    load_thumbnails();
+
     Application::redraw();
 }
 

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -399,22 +399,19 @@ void Gallery::handle_imagelist(const ImageListEvent event,
         }
     }
 
-    if (event == ImageListEvent::Remove) {
-        for (const auto& entry : entries) {
-            if (entry == layout.get_selected()) {
-                if (!layout.select(Layout::Right) &&
-                    !layout.select(Layout::Left)) {
-                    Log::info("No more images to view, exit");
-                    Application::self().exit(0);
-                    return;
-                }
-                switch_current();
-                break;
-            }
+    if (event == ImageListEvent::Remove && layout.get_selected()->removed) {
+        layout.update(); // correct the selected entry and update the layout
+
+        if (!layout.get_selected()) {
+            Log::info("No more images to view, exit");
+            Application::self().exit(0);
+            return;
         }
+        switch_current();
+    } else {
+        layout.update();
     }
 
-    layout.update();
     clear_invisible_thumbnails();
     load_thumbnails();
 
@@ -591,8 +588,8 @@ void Gallery::load_thumbnail(const ImageEntryPtr& entry)
 {
     {
         const std::scoped_lock lock(mutex);
-        active.insert(entry);
         queue.erase(entry);
+        active.insert(entry);
     }
 
     const size_t thumb_size = layout.get_thumb_size();
@@ -615,7 +612,7 @@ void Gallery::load_thumbnail(const ImageEntryPtr& entry)
 
     const std::scoped_lock lock(mutex);
     active.erase(entry);
-    if (pm) {
+    if (pm && !entry->removed) {
         cache.insert_or_assign(entry, pm);
         if (layout.is_visible(entry)) {
             Application::redraw();

--- a/src/gallery.cpp
+++ b/src/gallery.cpp
@@ -515,9 +515,7 @@ void Gallery::draw(const Layout::Thumbnail& tlay, Pixmap& wnd)
 void Gallery::load_thumbnails()
 {
     const std::scoped_lock lock(mutex);
-
     tpool.cancel();
-    queue.clear();
 
     ImageList& il = ImageList::self();
     const std::vector<Layout::Thumbnail>& scheme = layout.get_scheme();
@@ -588,8 +586,9 @@ void Gallery::load_thumbnail(const ImageEntryPtr& entry)
 {
     {
         const std::scoped_lock lock(mutex);
-        queue.erase(entry);
-        active.insert(entry);
+        if (cache.contains(entry) || entry->removed) {
+            return;
+        }
     }
 
     const size_t thumb_size = layout.get_thumb_size();
@@ -605,15 +604,18 @@ void Gallery::load_thumbnail(const ImageEntryPtr& entry)
                                            aspect == Aspect::Fill);
         if (!pm) {
             Application::self().add_event(AppEvent::FileRemove { entry->path });
-        } else if (pstore_enable) {
+            return;
+        }
+
+        if (pstore_enable) {
             pstore_save(entry, pm);
         }
     }
 
     const std::scoped_lock lock(mutex);
-    active.erase(entry);
-    if (pm && !entry->removed) {
+    if (!entry->removed) {
         cache.insert_or_assign(entry, pm);
+
         if (layout.is_visible(entry)) {
             Application::redraw();
         }
@@ -622,10 +624,7 @@ void Gallery::load_thumbnail(const ImageEntryPtr& entry)
 
 void Gallery::queue_thumbnail(const ImageEntryPtr& entry)
 {
-    if (!get_thumbnail(entry) &&   // not yet loaded
-        !queue.contains(entry) &&  // not queued
-        !active.contains(entry)) { // not currently loading
-        queue.insert(entry);
+    if (!cache.contains(entry)) {
         tpool.add([this, entry]() {
             load_thumbnail(entry);
         });

--- a/src/gallery.hpp
+++ b/src/gallery.hpp
@@ -10,7 +10,6 @@
 #include "threadpool.hpp"
 
 #include <mutex>
-#include <set>
 #include <unordered_map>
 
 class Gallery : public AppMode {
@@ -229,8 +228,6 @@ private:
      * ImageEntry caching allows determining the current index of the thumbnail.
      */
     std::unordered_map<ImageEntryPtr, Pixmap> cache;
-    std::set<ImageEntryPtr> queue;  ///< Loading queue
-    std::set<ImageEntryPtr> active; ///< Currently loading
 
     bool preload;      ///< Enable/disable preloading of invisible thumbnails
     size_t cache_size; ///< Max number of thumbnails in cache

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -21,7 +21,11 @@ void Layout::update()
     if (!sel_entry) {
         sel_entry = first_entry;
     }
-    assert(!sel_entry->removed);
+    if (sel_entry->removed && !select(Right) && !select(Left)) {
+        sel_entry = nullptr;
+        scheme.clear();
+        return;
+    }
 
     columns = std::max(static_cast<size_t>(1),
                        window.width / (thumb_size + thumb_padding));
@@ -133,11 +137,11 @@ bool Layout::select(const Direction dir)
     switch (dir) {
         case Direction::First:
             next = il.get(nullptr, ImageList::Dir::First);
-            row = 0;
+            row = col = 0;
             break;
         case Direction::Last:
             next = il.get(nullptr, ImageList::Dir::Last);
-            row = 0;
+            row = col = 0;
             break;
         case Direction::Up:
             next = il.get(sel_entry, -static_cast<ssize_t>(columns));
@@ -177,21 +181,27 @@ bool Layout::select(const Direction dir)
 
     if (next == sel_entry) {
         next = nullptr;
-    }
-
-    if (next) {
+    } else if (next) {
         if (col < 0) {
             --row;
+            sel_col = columns - 1;
         } else if (std::cmp_greater_equal(col, columns)) {
             ++row;
+            sel_col = 0;
+        } else {
+            sel_col = col;
         }
+
         if (row < 0) {
             sel_row = 0;
         } else {
             sel_row = row;
         }
+
         sel_entry = next;
-        update();
+        if (!is_visible(next)) {
+            update();
+        }
     }
 
     return !!next;
@@ -231,6 +241,16 @@ ImageEntryPtr Layout::get_selected() const
 
 bool Layout::is_visible(const ImageEntryPtr& entry) const
 {
+    if (scheme.empty() || !entry ||
+        // when imagelist was changed but layout has not caught up yet
+        // (like when thumb loader finished during image removal)
+        //
+        // not checking all because update will happen shortly
+        // invalidating the results of this call anyway
+        scheme.front().img->removed || scheme.back().img->removed) {
+        return false;
+    }
+
     ImageList& il = ImageList::self();
     return il.distance(entry, scheme.front().img) <= 0 &&
         il.distance(entry, scheme.back().img) >= 0;

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -136,25 +136,17 @@ bool Layout::select(const Direction dir)
 
     switch (dir) {
         case Direction::First:
-            next = il.get(nullptr, ImageList::Dir::First);
             row = col = 0;
             break;
         case Direction::Last:
-            next = il.get(nullptr, ImageList::Dir::Last);
             row = col = 0;
             break;
         case Direction::Up:
             next = il.get(sel_entry, -static_cast<ssize_t>(columns));
-            if (!next) {
-                next = il.get(nullptr, ImageList::Dir::First);
-            }
             --row;
             break;
         case Direction::Down:
             next = il.get(sel_entry, columns);
-            if (!next) {
-                next = il.get(nullptr, ImageList::Dir::Last);
-            }
             ++row;
             break;
         case Direction::Left:
@@ -167,16 +159,16 @@ bool Layout::select(const Direction dir)
             break;
         case Direction::PgUp:
             next = il.get(sel_entry, -static_cast<ssize_t>(columns * rows));
-            if (!next) {
-                next = il.get(nullptr, ImageList::Dir::First);
-            }
             break;
         case Direction::PgDown:
             next = il.get(sel_entry, columns * rows);
-            if (!next) {
-                next = il.get(nullptr, ImageList::Dir::Last);
-            }
             break;
+    }
+
+    if (!next) {
+        next = il.get(nullptr,
+                      is_forward(dir) ? ImageList::Dir::Last
+                                      : ImageList::Dir::First);
     }
 
     if (next == sel_entry) {

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -71,6 +71,7 @@ public:
 
     /**
      * Set currently selected thumbnail.
+     * Always reflows to keep the image in the center of attention.
      * @param image image entry to select
      */
     void select(const ImageEntryPtr& image);

--- a/src/layout.hpp
+++ b/src/layout.hpp
@@ -21,6 +21,11 @@ public:
         PgDown,
     };
 
+    static constexpr bool is_forward(const Direction dir)
+    {
+        return dir == Last || dir == Down || dir == Right || dir == PgDown;
+    }
+
     /** Thumbnail instance with coordinates. */
     struct Thumbnail {
         ImageEntryPtr img; ///< Image entry

--- a/test/layout_test.cpp
+++ b/test/layout_test.cpp
@@ -126,23 +126,66 @@ TEST_F(LayoutTest, BaseScheme)
             ASSERT_EQ(it.row, 0UL);
         }
     }
+
+    // Test size larger than what can fit in the scheme
+    InitLayout(30);
+
+    ASSERT_EQ(layout.get_scheme()[0].img->path, "exec://0");
 }
 
 TEST_F(LayoutTest, SelectByImage)
 {
     InitLayout(30);
 
-    ASSERT_EQ(layout.get_scheme()[0].img->path, "exec://0");
-
     const Layout::Thumbnail* th = Select(5);
 
     ASSERT_TRUE(th);
     ASSERT_TRUE(th->img);
-    ASSERT_EQ(th->img, layout.get_selected());
+    ASSERT_EQ(th->img->index, layout.get_selected()->index);
     ASSERT_EQ(th->col, 0UL);
     ASSERT_EQ(th->row, 1UL);
 
     ASSERT_EQ(layout.get_scheme()[0].img->path, "exec://0");
+}
+
+TEST_F(LayoutTest, SelectByImageOffscreen)
+{
+    InitLayout(30);
+
+    const Layout::Thumbnail* th = Select(28);
+
+    ASSERT_TRUE(th);
+    ASSERT_TRUE(th->img);
+    ASSERT_EQ(th->img->index, layout.get_selected()->index);
+    ASSERT_EQ(th->col, 3UL);
+    ASSERT_EQ(th->row, 3UL);
+
+    ASSERT_EQ(layout.get_scheme().back().img->path, "exec://29");
+}
+
+TEST_F(LayoutTest, SelectByPoint)
+{
+    InitLayout(30);
+    const Layout::Thumbnail& th = layout.get_scheme()[5];
+    const ssize_t size = static_cast<ssize_t>(layout.get_thumb_size());
+
+    const std::vector<Point> offsets = {
+        { 0,        0        },
+        { size - 1, 0        },
+        { 0,        size - 1 },
+        { size - 1, size - 1 },
+        { 1,        1        },
+        { size / 2, size / 2 },
+    };
+
+    for (const auto offset : offsets) {
+        layout.select(th.pos + offset);
+
+        ASSERT_EQ(layout.get_scheme()[0].img->path, "exec://0");
+        ASSERT_EQ(layout.get_selected()->index, th.img->index);
+
+        Select(0);
+    }
 }
 
 TEST_F(LayoutTest, SelectFirstLast)


### PR DESCRIPTION
Refreshes thumbnail queue only when meaningful changes have been done - switching entry or modifying the layout by other means.

Given how quick redrawing already was, there is no benefit in having these heavier operations in `redraw` because every update corresponds to 1 redraw and none get skipped unless the main loop is blocked by multiple changes caused by the lua code.

This makes for the following comparison:

When recalculating on every redraw:
- `-`: recalculates even when unrelated changes have been made (color change, text size, etc.)
- `+`: recalculates only once when user calls `gallery.select()` multiple times in a row (probably trying to select a specific image -> set_current should be exposed to the api instead)

The opposite is the case for my approach.

I found a fun quirk for why the layout tests were not covering the `col<0` and `col > max` cases. I am not making a test to force that scenario though. It is much easier to adjust the implementation code, which I had to do anyway because of the update skipping.