### PR TITLE
Fix stopping key repeat on old/unrelated key release

### DIFF
--- a/src/ui_wayland.cpp
+++ b/src/ui_wayland.cpp
@@ -35,7 +35,7 @@ public:
                                   struct wl_surface*)
     {
         const UiWayland* ui = reinterpret_cast<UiWayland*>(data);
-        ui->xkb.stop_repeat();
+        ui->xkb.stop_repeat(XKB_KEY_NoSymbol);
     }
 
     static void on_keyboard_modifiers(void* data, struct wl_keyboard*, uint32_t,
@@ -68,11 +68,11 @@ public:
     {
         UiWayland* ui = reinterpret_cast<UiWayland*>(data);
 
+        key += 8;
+        const xkb_keysym_t keysym = ui->xkb.get_keysym(key);
         if (state == WL_KEYBOARD_KEY_STATE_RELEASED) {
-            ui->xkb.stop_repeat();
+            ui->xkb.stop_repeat(keysym);
         } else if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-            key += 8;
-            const xkb_keysym_t keysym = ui->xkb.get_keysym(key);
             if (keysym != XKB_KEY_NoSymbol) {
                 Application::self().add_event(
                     AppEvent::KeyPress { keysym, ui->xkb.get_modifiers() });

--- a/src/xkb.cpp
+++ b/src/xkb.cpp
@@ -67,9 +67,11 @@ void Xkb::start_repeat(const xkb_keycode_t code)
     }
 }
 
-void Xkb::stop_repeat() const
+void Xkb::stop_repeat(const xkb_keycode_t key) const
 {
-    repeat_timer.reset(0, 0);
+    if (key == XKB_KEY_NoSymbol || key == repeat_key) {
+        repeat_timer.reset(0, 0);
+    }
 }
 
 std::tuple<xkb_keysym_t, size_t> Xkb::get_repeat() const

--- a/src/xkb.hpp
+++ b/src/xkb.hpp
@@ -46,8 +46,9 @@ public:
 
     /**
      * Stop repeat mode.
+     * @param key key to stop repeat or XKB_KEY_NoSymbol to stop unconditionally
      */
-    void stop_repeat() const;
+    void stop_repeat(const xkb_keycode_t key) const;
 
     /**
      * Get repeat description.


### PR DESCRIPTION
Hi, 
so there is an issue that auto repeat stops when any key is released even if that key is not repeated any more. It causes problems for example in gallery mode when quickly changing direction, it just stops switching image even if one arrow is pressed.