### PR TITLE
Prevent blocking when reading drag-and-drop data.

### DIFF
--- a/src/ui_wayland.cpp
+++ b/src/ui_wayland.cpp
@@ -410,7 +410,9 @@ public:
         // receive the data from the offer
         int fds[2];
         if (pipe2(fds, O_CLOEXEC) == -1) {
-            Log::error(errno, "Failed to create piep");
+            Log::error(
+                errno,
+                "Failed to create pipe for receiving drag-and-drop data");
             ui->wl.dataoffer.free();
             return;
         }
@@ -423,21 +425,27 @@ public:
             .events = POLLIN,
             .revents = 0,
         };
-        if (poll(&pfd, 1, 1000) <= 0) {
-            Log::error(errno, "Failed to poll pipe");
-            close(fds[0]);
-            ui->wl.dataoffer.free();
-            return;
-        }
         std::string offer_data;
         while (true) {
+            const int poll_rc = poll(&pfd, 1, 1000);
+            if (poll_rc <= 0) {
+                if (poll_rc < 0) {
+                    Log::error(errno,
+                               "Failed to poll pipe for drag-and-drop data");
+                } else {
+                    Log::error("Timeout while waiting for drag-and-drop data");
+                }
+                close(fds[0]);
+                ui->wl.dataoffer.free();
+                return;
+            }
             uint8_t buffer[512];
             const ssize_t rc = read(fds[0], buffer, sizeof(buffer));
             if (rc == 0) {
                 break;
             }
             if (rc == -1 && errno != EAGAIN) {
-                Log::error(errno, "Unable to read pipe");
+                Log::error(errno, "Unable to read drag-and-drop data");
                 close(fds[0]);
                 ui->wl.dataoffer.free();
                 return;


### PR DESCRIPTION
The drag-and-drop data is provided by an external program, through a pipe. If the other program writes some data but doesn't close the pipe, the current implementation will block forever, waiting for data that will never come.

By doing a `poll()` before *every* read, we ensure that the `read()` can not block, and the `poll()` itself has a timeout.

It also prevents logging `errno` when `poll()` returns 0, since `poll()` did not set it in that case (it is not an error, it just means no fds are ready).

Additionally, this PR extends the error messages to indicate why a pipe was being read in the first place, to more quickly point users to the source of the problem.