### PR TITLE
Fix sanitization logic bypass

### DIFF
--- a/src/log.hpp
+++ b/src/log.hpp
@@ -169,6 +169,6 @@ private:
             }
         }
 
-        return msg;
+        return result;
     }
 };


### PR DESCRIPTION
We were returning the unmodified string rather than the sanitized one.