### PR TITLE
xkb.cpp: add missing header

### DIFF
--- a/src/xkb.cpp
+++ b/src/xkb.cpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include <cassert>
+#include <tuple>
 
 Xkb::Xkb()
     : context(xkb_context_new(XKB_CONTEXT_NO_FLAGS))


### PR DESCRIPTION
Fixes `xkb.cpp:86:17: error: 'make_tuple' is not a member of 'std'`