### PR TITLE
video: add FFmpeg version requirement

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,10 +110,10 @@ else
     webp = dependency('', required: false)
 endif
 # Video storyboard
-avformat = dependency('libavformat', required: get_option('video'))
-avcodec = dependency('libavcodec', required: get_option('video'))
-avutil = dependency('libavutil', required: get_option('video'))
-swscale = dependency('libswscale', required: get_option('video'))
+avformat = dependency('libavformat', version: '>=60.16.100', required: get_option('video'))
+avcodec = dependency('libavcodec', version: '>=60.31.102', required: get_option('video'))
+avutil = dependency('libavutil', version: '>=58.29.100', required: get_option('video'))
+swscale = dependency('libswscale', version: '>=7.5.100', required: get_option('video'))
 if avformat.found() and avcodec.found() and avutil.found() and swscale.found()
     video = declare_dependency(
         dependencies: [avformat, avcodec, avutil, swscale],


### PR DESCRIPTION
av_packet_side_data_get() was added in FFmpeg-6.1 (https://github.com/FFmpeg/FFmpeg/blob/release/6.1/doc/APIchanges#L28)

Align versions for all libs with 6.1.

It failed with ffmpeg-4.4.8:
```
../swayimg-5.6/src/formats/video.cpp: In member function ‘int {anonymous}::ImageFormatVideo::AvDecoder::read_rotation01:49 [36765/68921]
../swayimg-5.6/src/formats/video.cpp:541:59: error: ‘AVCodecParameters’ {aka ‘struct AVCodecParameters’} has no member named ‘coded_side
_data’                                                                                                                                  
  541 |                     av_packet_side_data_get(st->codecpar->coded_side_data,                                                      
      |                                                           ^~~~~~~~~~~~~~~                                                       
../swayimg-5.6/src/formats/video.cpp:542:59: error: ‘AVCodecParameters’ {aka ‘struct AVCodecParameters’} has no member named ‘nb_coded_s
ide_data’                                                                                                                               
  542 |                                             st->codecpar->nb_coded_side_data,                                      
      |                                                           ^~~~~~~~~~~~~~~~~~
../swayimg-5.6/src/formats/video.cpp:541:21: error: ‘av_packet_side_data_get’ was not declared in this scope; did you mean ‘av_packet_si
de_data_name’?                                                      
  541 |                     av_packet_side_data_get(st->codecpar->coded_side_data,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~                 
      |                     av_packet_side_data_name  
```