### PR TITLE
xkb: Add missing header for libcxx-23

### DIFF
--- a/src/xkb.cpp
+++ b/src/xkb.cpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include <cassert>
+#include <cstdlib>
 #include <tuple>
 
 Xkb::Xkb()


### PR DESCRIPTION
Starting with libcxx-23 transitive headers are being removed from their C++ standard library.
```

clang++ -Iswayimg.p -I. -I../swayimg-5.6 -I../swayimg-5.6/src/external -I/usr/include/libdrm -I/usr/include/freetype2 -I/usr/include/lua
jit-2.1 -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -std=c++20 -O2 -pipe -march=zn
ver2 -frecord-gcc-switches -ftrivial-auto-var-init=zero -Werror=odr -Werror=strict-aliasing -pthread -MD -MQ swayimg.p/src_xkb.cpp.o -MF
 swayimg.p/src_xkb.cpp.o.d -o swayimg.p/src_xkb.cpp.o -c ../swayimg-5.6/src/xkb.cpp                                                     
../swayimg-5.6/src/xkb.cpp:176:33: error: no member named 'mbstowcs' in namespace 'std'; did you mean 'mbsrtowcs'?                      
  176 |         const size_t len = std::mbstowcs(wide.data(), name.c_str(),                            
      |                                 ^~~~~~~~                                                                                        
      |                                 mbsrtowcs
```