### PR TITLE
viewer: zoom relative to image size

### DIFF
--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -534,7 +534,7 @@ void Viewer::handle_mmove(const InputMouse& input, const Point&,
 
 void Viewer::handle_pinch(const double scale_delta)
 {
-    set_scale(scale + scale_delta * pinch_factor);
+    set_scale(scale + (scale_delta * (scale / (1 / pinch_factor))));
 }
 
 void Viewer::handle_imagelist(const ImageListEvent event,


### PR DESCRIPTION
before this the zooming used to add a fixed size to the image which caused small scaled images to change too much and big scaled images to hardly change

- now the image will scale relative to its own size
- pinch_factor had to be inverted for it to make sense
- pinch factor between 5.0 to 0.5 were working fine
- pinching in gallery mode also looks good
- i couldnt figure out how to run tests

left is my change, right is the original behaviour. both done with default config

https://github.com/user-attachments/assets/84c5df0e-3ce4-4a97-af3f-d3c33b13a9d9


https://github.com/user-attachments/assets/716c4d7f-87b1-4f42-9505-0f1af5e60b1b

